### PR TITLE
Update Learn More link for Fluxnova

### DIFF
--- a/client/src/app/tabs/EngineProfile.js
+++ b/client/src/app/tabs/EngineProfile.js
@@ -29,7 +29,7 @@ import { Fill } from '../slot-fill';
 import { ENGINES, ENGINE_LABELS, ENGINE_PROFILES, getLatestStable } from '../../util/Engines';
 
 const HELP_LINKS = {
-  [ ENGINES.FLUXNOVA ]: 'https://docs.fluxnova.finos.org/manual/latest/',
+  [ ENGINES.FLUXNOVA ]: 'https://docs.fluxnova.finos.org/',
   [ ENGINES.CLOUD ]: 'https://docs.camunda.io/?utm_source=modeler&utm_medium=referral'
 };
 


### PR DESCRIPTION
### Proposed Changes

The 'Learn more' link in the change execution platform widget should point to https://docs.fluxnova.finos.org/. The current link is broken.

closes #7 