### PR TITLE
Remove copyright licences from job execution and form rebranding files

### DIFF
--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/JobExecutionExtensionProvider.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/JobExecutionExtensionProvider.js
@@ -1,12 +1,3 @@
-/**
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information regarding copyright
- * ownership.
- *
- * Camunda licenses this file to you under the MIT; you may not use this file
- * except in compliance with the MIT License.
- */
 import { createJobExecutionGroup as defaultCreateJobExecutionGroup } from './props/JobExecutionGroup';
 
 

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/index.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/index.js
@@ -1,13 +1,3 @@
-/**
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information regarding copyright
- * ownership.
- *
- * Camunda licenses this file to you under the MIT; you may not use this file
- * except in compliance with the MIT License.
- */
-
 import JobExecutionExtensionProvider from './JobExecutionExtensionProvider';
 
 export default {

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/JobExecutionGroup.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/JobExecutionGroup.js
@@ -1,13 +1,3 @@
-/**
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information regarding copyright
- * ownership.
- *
- * Camunda licenses this file to you under the MIT; you may not use this file
- * except in compliance with the MIT License.
- */
-
 import { Group } from '@bpmn-io/properties-panel';
 import { JobExecutionProps } from './JobExecutionProps';
 import translate from 'diagram-js/lib/i18n/translate/translate';

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/JobExecutionProps.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/JobExecutionProps.js
@@ -1,13 +1,3 @@
-/**
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information regarding copyright
- * ownership.
- *
- * Camunda licenses this file to you under the MIT; you may not use this file
- * except in compliance with the MIT License.
- */
-
 import {
   getBusinessObject,
   is

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-form-group/PropertiesPanelGroupsExtension.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-form-group/PropertiesPanelGroupsExtension.js
@@ -1,13 +1,3 @@
-/**
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information regarding copyright
- * ownership.
- *
- * Camunda licenses this file to you under the MIT; you may not use this file
- * except in compliance with the MIT License.
- */
-
 import { createBpmnFormGroup } from './props/BpmnFormTypeGroup';
 
 

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-form-group/index.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-form-group/index.js
@@ -1,13 +1,3 @@
-/**
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information regarding copyright
- * ownership.
- *
- * Camunda licenses this file to you under the MIT; you may not use this file
- * except in compliance with the MIT License.
- */
-
 import PropertiesPanelGroupsExtension from './PropertiesPanelGroupsExtension';
 
 export default {

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-form-group/props/BpmnFormTypeGroup.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-form-group/props/BpmnFormTypeGroup.js
@@ -1,13 +1,3 @@
-/**
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information regarding copyright
- * ownership.
- *
- * Camunda licenses this file to you under the MIT; you may not use this file
- * except in compliance with the MIT License.
- */
-
 import { Group } from '@bpmn-io/properties-panel';
 import { FormProps } from './BpmnFormProps';
 import translate from 'diagram-js/lib/i18n/translate/translate';


### PR DESCRIPTION
This PR is to remove Camunda copyright statements on files that we had previously added unnecessarily to which do not need to be there.
These features do not contain any code copied over from the Camunda 7 CE version. The files do contain code from the bpmn.io repo (https://github.com/bpmn-io/bpmn-js-properties-panel) so we only need to ensure the LICENCE file references MIT.
