### PR TITLE
Feature/ad hoc subprocess support

### DIFF
--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -820,7 +820,7 @@ export class BpmnEditor extends CachedComponent {
       exporter: {
         name,
         version
-      },
+      }
     }, handleMiddlewareExtensions, 'platform');
 
     if (warnings.length && isFunction(onError)) {

--- a/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
@@ -29,6 +29,8 @@ import popupMenuTracking from 'bpmn-js-tracking/lib/features/popup-menu';
 import paletteTracking from 'bpmn-js-tracking/lib/features/palette';
 
 import { BpmnImprovedCanvasModule } from './features/improved-canvas';
+import FluxnovaBpmnModdle from '../../../../moddle/fluxnova-bpmn-moddle';
+import FluxnovaModelerModdle from '../../../../moddle/fluxnova-bpmn-modeler-moddle';
 
 import Flags, {
   DISABLE_ADJUST_ORIGIN,
@@ -60,7 +62,11 @@ export default class PlatformBpmnModeler extends BpmnModeler {
     super({
       ...otherOptions,
       additionalModules,
-      moddleExtensions,
+      moddleExtensions: {
+        fluxnova: FluxnovaBpmnModdle,
+        modeler: FluxnovaModelerModdle,
+        ...moddleExtensions
+      },
       disableAdjustOrigin: Flags.get(DISABLE_ADJUST_ORIGIN),
       canvas: {
         autoFocus: true

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/AdHocSubProcessExtensionProvider.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/AdHocSubProcessExtensionProvider.js
@@ -1,0 +1,52 @@
+import { createAdHocSubProcessGroup as defaultAdHocSubProcessGroup } from './props/AdHocSubProcessGroup';
+
+
+export default class AdHocSubProcessExtensionProvider {
+
+  constructor(propertiesPanel, createAdHocSubProcessGroup = defaultAdHocSubProcessGroup) {
+    propertiesPanel.registerProvider(100, this);
+    this.createAdHocSubProcessGroup = createAdHocSubProcessGroup;
+  }
+
+  getGroups(element) {
+    return groups => {
+
+      const extendedAdHocGroup = groupExists(groups, 'ad_hoc_subprocess');
+
+      groups = groups.slice();
+
+      if (extendedAdHocGroup === -1) {
+        const adHocSubProcessGroup = this.createAdHocSubProcessGroup(element);
+        if (adHocSubProcessGroup) {
+          let adjacentIndex = groups.length - 2;
+          groups.forEach((group, index) => {
+            if (isAdjacentGroup(group)) {
+              adjacentIndex = index + 1;
+            }
+          });
+
+          groups.splice(adjacentIndex, 0, adHocSubProcessGroup);
+        }
+      }
+
+      return groups;
+    };
+  }
+}
+
+AdHocSubProcessExtensionProvider.$inject = [ 'propertiesPanel' ];
+
+function isAdjacentGroup(group) {
+  // Position after subprocess-specific groups
+  const adjacentGroupIds = [
+    'CamundaPlatform__Subprocess',
+    'subprocess'
+  ];
+  return adjacentGroupIds.includes(group.id);
+}
+
+function groupExists(groups, groupId) {
+  return groups.reduce((acc, group, index) => {
+    return groupId === group.id ? index : acc;
+  }, -1);
+}

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/AdHocSubProcessExtensionProvider.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/AdHocSubProcessExtensionProvider.js
@@ -1,23 +1,24 @@
-import { createAdHocSubProcessGroup as defaultAdHocSubProcessGroup } from './props/AdHocSubProcessGroup';
+import { createAdHocSubProcessGroups as defaultAdHocSubProcessGroups } from './props/AdHocSubProcessGroup';
 
 
 export default class AdHocSubProcessExtensionProvider {
 
-  constructor(propertiesPanel, createAdHocSubProcessGroup = defaultAdHocSubProcessGroup) {
+  constructor(propertiesPanel, createAdHocSubProcessGroups = defaultAdHocSubProcessGroups) {
     propertiesPanel.registerProvider(100, this);
-    this.createAdHocSubProcessGroup = createAdHocSubProcessGroup;
+    this.createAdHocSubProcessGroups = createAdHocSubProcessGroups;
   }
 
   getGroups(element) {
     return groups => {
 
-      const extendedAdHocGroup = groupExists(groups, 'ad_hoc_subprocess');
+      const hasActiveTasksGroup = groupExists(groups, 'ad_hoc_subprocess_active_tasks') !== -1;
+      const hasCompletionGroup = groupExists(groups, 'ad_hoc_subprocess_completion') !== -1;
 
       groups = groups.slice();
 
-      if (extendedAdHocGroup === -1) {
-        const adHocSubProcessGroup = this.createAdHocSubProcessGroup(element);
-        if (adHocSubProcessGroup) {
+      if (!hasActiveTasksGroup && !hasCompletionGroup) {
+        const adHocSubProcessGroups = this.createAdHocSubProcessGroups(element);
+        if (adHocSubProcessGroups.length) {
           let adjacentIndex = groups.length - 2;
           groups.forEach((group, index) => {
             if (isAdjacentGroup(group)) {
@@ -25,7 +26,7 @@ export default class AdHocSubProcessExtensionProvider {
             }
           });
 
-          groups.splice(adjacentIndex, 0, adHocSubProcessGroup);
+          groups.splice(adjacentIndex, 0, ...adHocSubProcessGroups);
         }
       }
 

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/__tests__/AdHocSubProcessExtensionProviderSpec.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/__tests__/AdHocSubProcessExtensionProviderSpec.js
@@ -1,0 +1,124 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import AdHocSubProcessExtensionProvider from '../AdHocSubProcessExtensionProvider';
+
+describe('AdHocSubProcessExtensionProvider', function() {
+  let propertiesPanel;
+
+  beforeEach(function() {
+    propertiesPanel = { registerProvider: sinon.spy() };
+  });
+
+  it('should register provider with propertiesPanel', function() {
+    new AdHocSubProcessExtensionProvider(propertiesPanel);
+    expect(propertiesPanel.registerProvider.calledOnce).to.be.true;
+    expect(propertiesPanel.registerProvider.firstCall.args[0]).to.equal(100);
+  });
+
+  describe('#getGroups', function() {
+    let provider, createAdHocSubProcessGroupsStub;
+
+    beforeEach(function() {
+      createAdHocSubProcessGroupsStub = sinon.stub();
+      provider = new AdHocSubProcessExtensionProvider(propertiesPanel, createAdHocSubProcessGroupsStub);
+    });
+
+    it('should not add groups if already present', function() {
+      const groups = [
+        { id: 'ad_hoc_subprocess_active_tasks', entries: [] },
+        { id: 'ad_hoc_subprocess_completion', entries: [] },
+        { id: 'other', entries: [] }
+      ];
+      const getGroups = provider.getGroups({});
+      const result = getGroups(groups);
+      expect(result.filter(g => g.id === 'ad_hoc_subprocess_active_tasks').length).to.equal(1);
+      expect(result.filter(g => g.id === 'ad_hoc_subprocess_completion').length).to.equal(1);
+      expect(createAdHocSubProcessGroupsStub.called).to.be.false;
+    });
+
+    it('should add both groups if neither present and groups are created', function() {
+      createAdHocSubProcessGroupsStub.returns([
+        { id: 'ad_hoc_subprocess_active_tasks', entries: [] },
+        { id: 'ad_hoc_subprocess_completion', entries: [] }
+      ]);
+      const groups = [
+        { id: 'other', entries: [] },
+        { id: 'another', entries: [] }
+      ];
+      const getGroups = provider.getGroups({});
+      const result = getGroups(groups);
+      expect(result.find(g => g.id === 'ad_hoc_subprocess_active_tasks')).to.exist;
+      expect(result.find(g => g.id === 'ad_hoc_subprocess_completion')).to.exist;
+    });
+
+    it('should not add groups if createAdHocSubProcessGroups returns empty array', function() {
+      createAdHocSubProcessGroupsStub.returns([]);
+      const groups = [
+        { id: 'other', entries: [] },
+        { id: 'another', entries: [] }
+      ];
+      const getGroups = provider.getGroups({});
+      const result = getGroups(groups);
+      expect(result.find(g => g.id === 'ad_hoc_subprocess_active_tasks')).to.not.exist;
+      expect(result.find(g => g.id === 'ad_hoc_subprocess_completion')).to.not.exist;
+    });
+
+    it('should insert both groups after subprocess adjacent group', function() {
+      createAdHocSubProcessGroupsStub.returns([
+        { id: 'ad_hoc_subprocess_active_tasks', entries: [] },
+        { id: 'ad_hoc_subprocess_completion', entries: [] }
+      ]);
+      const groups = [
+        { id: 'foo', entries: [] },
+        { id: 'subprocess', entries: [] },
+        { id: 'bar', entries: [] }
+      ];
+      const getGroups = provider.getGroups({});
+      const result = getGroups(groups);
+      const activeTasksIndex = result.findIndex(g => g.id === 'ad_hoc_subprocess_active_tasks');
+      const subprocessIndex = result.findIndex(g => g.id === 'subprocess');
+      expect(activeTasksIndex).to.equal(subprocessIndex + 1);
+    });
+
+    it('should insert both groups after CamundaPlatform__Subprocess group', function() {
+      createAdHocSubProcessGroupsStub.returns([
+        { id: 'ad_hoc_subprocess_active_tasks', entries: [] },
+        { id: 'ad_hoc_subprocess_completion', entries: [] }
+      ]);
+      const groups = [
+        { id: 'foo', entries: [] },
+        { id: 'CamundaPlatform__Subprocess', entries: [] },
+        { id: 'bar', entries: [] }
+      ];
+      const getGroups = provider.getGroups({});
+      const result = getGroups(groups);
+      const activeTasksIndex = result.findIndex(g => g.id === 'ad_hoc_subprocess_active_tasks');
+      const camundaIndex = result.findIndex(g => g.id === 'CamundaPlatform__Subprocess');
+      expect(activeTasksIndex).to.equal(camundaIndex + 1);
+    });
+
+    it('should preserve other groups in correct order', function() {
+      createAdHocSubProcessGroupsStub.returns([
+        { id: 'ad_hoc_subprocess_active_tasks', entries: [] },
+        { id: 'ad_hoc_subprocess_completion', entries: [] }
+      ]);
+      const groups = [
+        { id: 'group1', entries: [] },
+        { id: 'subprocess', entries: [] },
+        { id: 'group2', entries: [] },
+        { id: 'group3', entries: [] }
+      ];
+      const getGroups = provider.getGroups({});
+      const result = getGroups(groups);
+      const ids = result.map(g => g.id);
+      expect(ids).to.deep.equal([
+        'group1',
+        'subprocess',
+        'ad_hoc_subprocess_active_tasks',
+        'ad_hoc_subprocess_completion',
+        'group2',
+        'group3'
+      ]);
+    });
+  });
+});

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/ad-hoc-subprocess/index.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/ad-hoc-subprocess/index.js
@@ -1,0 +1,6 @@
+import AdHocSubProcessExtensionProvider from '../AdHocSubProcessExtensionProvider';
+
+export default {
+  __init__: [ 'adHocSubProcessExtensionProvider' ],
+  adHocSubProcessExtensionProvider: [ 'type', AdHocSubProcessExtensionProvider ]
+};

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/index.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/index.js
@@ -1,6 +1,11 @@
 import JobExecutionExtensionProvider from './JobExecutionExtensionProvider';
+import AdHocSubProcessExtensionProvider from './AdHocSubProcessExtensionProvider';
 
 export default {
-  __init__: [ 'bpmnJobExecutionExtensionProvider' ],
-  bpmnJobExecutionExtensionProvider: [ 'type', JobExecutionExtensionProvider ]
+  __init__: [
+    'bpmnJobExecutionExtensionProvider',
+    'adHocSubProcessExtensionProvider'
+  ],
+  bpmnJobExecutionExtensionProvider: [ 'type', JobExecutionExtensionProvider ],
+  adHocSubProcessExtensionProvider: [ 'type', AdHocSubProcessExtensionProvider ]
 };

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessGroup.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessGroup.js
@@ -6,19 +6,30 @@ import {
 } from './AdHocSubProcessProps';
 
 
-export function createAdHocSubProcessGroup(element) {
+export function createAdHocSubProcessGroups(element) {
   if (!is(element, 'bpmn:AdHocSubProcess')) {
-    return null;
+    return [];
   }
 
-  const group = {
-    id: 'ad_hoc_subprocess',
-    label: 'Ad Hoc Subprocess',
+  const activeTasksGroup = {
+    id: 'ad_hoc_subprocess_active_tasks',
+    label: 'Active Tasks',
     entries: [
-      ...ActiveTasksCollectionProps({ element }),
+      ...ActiveTasksCollectionProps({ element })
+    ]
+  };
+
+  const completionGroup = {
+    id: 'ad_hoc_subprocess_completion',
+    label: 'Completion',
+    entries: [
       ...CompletionProps({ element })
     ]
   };
 
-  return group;
+  return [ activeTasksGroup, completionGroup ];
+}
+
+export function createAdHocSubProcessGroup(element) {
+  return createAdHocSubProcessGroups(element)[0] || null;
 }

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessGroup.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessGroup.js
@@ -1,0 +1,24 @@
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  ActiveTasksCollectionProps,
+  CompletionProps
+} from './AdHocSubProcessProps';
+
+
+export function createAdHocSubProcessGroup(element) {
+  if (!is(element, 'bpmn:AdHocSubProcess')) {
+    return null;
+  }
+
+  const group = {
+    id: 'ad_hoc_subprocess',
+    label: 'Ad Hoc Subprocess',
+    entries: [
+      ...ActiveTasksCollectionProps({ element }),
+      ...CompletionProps({ element })
+    ]
+  };
+
+  return group;
+}

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessGroup.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessGroup.js
@@ -29,7 +29,3 @@ export function createAdHocSubProcessGroups(element) {
 
   return [ activeTasksGroup, completionGroup ];
 }
-
-export function createAdHocSubProcessGroup(element) {
-  return createAdHocSubProcessGroups(element)[0] || null;
-}

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessProps.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessProps.js
@@ -1,0 +1,335 @@
+import { getBusinessObject, is } from 'bpmn-js/lib/util/ModelUtil';
+import { isDefined } from 'min-dash';
+
+import {
+  TextFieldEntry,
+  isTextFieldEntryEdited,
+  CheckboxEntry,
+  isCheckboxEntryEdited
+} from '@bpmn-io/properties-panel';
+
+import { useService } from 'bpmn-js-properties-panel';
+
+import { without } from 'min-dash';
+
+
+export function ActiveTasksCollectionProps(props) {
+  const { element } = props;
+
+  if (!is(element, 'bpmn:AdHocSubProcess')) {
+    return [];
+  }
+
+  return [
+    {
+      id: 'activeTasksCollection',
+      component: ActiveTasksCollection,
+      isEdited: isTextFieldEntryEdited
+    }
+  ];
+}
+
+function ActiveTasksCollection(props) {
+  const { element } = props;
+
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+  const bpmnFactory = useService('bpmnFactory');
+  const debounce = useService('debounceInput');
+
+  const businessObject = getBusinessObject(element);
+
+  const getValue = () => {
+    const property = getFluxnovaProperty(businessObject, 'activeTasksCollection');
+    return property ? property.value : '';
+  };
+
+  const setValue = (value) => {
+    const commands = [];
+
+    let extensionElements = businessObject.get('extensionElements');
+
+    // (1) ensure extension elements exist
+    if (!extensionElements) {
+      extensionElements = createElement(
+        'bpmn:ExtensionElements',
+        { values: [] },
+        businessObject,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: businessObject,
+          properties: { extensionElements }
+        }
+      });
+    }
+
+    // (2) ensure fluxnova:Properties container exists
+    let fluxnovaProperties = getExtensionElementsList(businessObject, 'fluxnova:Properties')[0];
+
+    if (!fluxnovaProperties) {
+      fluxnovaProperties = createElement(
+        'fluxnova:Properties',
+        { values: [] },
+        extensionElements,
+        bpmnFactory
+      );
+
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: extensionElements,
+          properties: {
+            values: [ ...extensionElements.get('values'), fluxnovaProperties ]
+          }
+        }
+      });
+    }
+
+    // (3) ensure activeTasksCollection property exists or update it
+    const activeTasksProperty = fluxnovaProperties.get('values')?.find((v) => v.name === 'activeTasksCollection');
+
+    if (value && value.trim()) {
+      if (activeTasksProperty) {
+        // Update existing property
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: activeTasksProperty,
+            properties: { value }
+          }
+        });
+      } else {
+        // Create new property
+        const property = createElement(
+          'fluxnova:Property',
+          { name: 'activeTasksCollection', value },
+          fluxnovaProperties,
+          bpmnFactory
+        );
+
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: fluxnovaProperties,
+            properties: {
+              values: [ ...(fluxnovaProperties.get('values') || []), property ]
+            }
+          }
+        });
+      }
+    } else if (activeTasksProperty) {
+      // Remove property if value is empty
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: fluxnovaProperties,
+          properties: {
+            values: without(fluxnovaProperties.get('values'), activeTasksProperty)
+          }
+        }
+      });
+    }
+
+    // (4) commit all updates
+    if (commands.length) {
+      commandStack.execute('properties-panel.multi-command-executor', commands);
+    }
+  };
+
+  return TextFieldEntry({
+    element,
+    id: 'activeTasksCollection',
+    label: translate('Active Tasks Collection'),
+    getValue,
+    setValue,
+    debounce,
+    description: translate('Expression, variable reference, or comma-separated task IDs (e.g., ${taskList} or taskA,taskB)')
+  });
+}
+
+
+export function CompletionProps(props) {
+  const { element } = props;
+
+  if (!is(element, 'bpmn:AdHocSubProcess')) {
+    return [];
+  }
+
+  const entries = [
+    {
+      id: 'completionCondition',
+      component: CompletionCondition,
+      isEdited: isTextFieldEntryEdited
+    },
+    {
+      id: 'cancelRemainingInstances',
+      component: CancelRemainingInstances,
+      isEdited: isCheckboxEntryEdited
+    }
+  ];
+
+  return entries;
+}
+
+function CompletionCondition(props) {
+  const { element } = props;
+
+  const bpmnFactory = useService('bpmnFactory');
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const businessObject = getBusinessObject(element);
+
+  const getValue = () => {
+    const completionCondition = businessObject.get('completionCondition');
+    return completionCondition ? completionCondition.get('body') : '';
+  };
+
+  const setValue = (value) => {
+    const commands = [];
+
+    let completionCondition = businessObject.get('completionCondition');
+
+    if (value && value.trim()) {
+      if (!completionCondition) {
+        // Create the Expression element
+        completionCondition = createElement(
+          'bpmn:Expression',
+          { body: value },
+          businessObject,
+          bpmnFactory
+        );
+
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: businessObject,
+            properties: { completionCondition }
+          }
+        });
+      } else {
+        // Update existing Expression
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: completionCondition,
+            properties: { body: value }
+          }
+        });
+      }
+    } else if (completionCondition) {
+      // Remove completion condition if empty
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: businessObject,
+          properties: { completionCondition: undefined }
+        }
+      });
+    }
+
+    if (commands.length) {
+      commandStack.execute('properties-panel.multi-command-executor', commands);
+    }
+  };
+
+  return TextFieldEntry({
+    element,
+    id: 'completionCondition',
+    label: translate('Completion Condition'),
+    getValue,
+    setValue,
+    debounce,
+    description: translate('BPMN expression for ad hoc completion (e.g., ${approved == true})')
+  });
+}
+
+function CancelRemainingInstances(props) {
+  const { element } = props;
+
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+
+  const businessObject = getBusinessObject(element);
+
+  const getValue = () => {
+    const value = businessObject.get('cancelRemainingInstances');
+    return isDefined(value) ? value : true;
+  };
+
+  const setValue = (value) => {
+    commandStack.execute('element.updateModdleProperties', {
+      element,
+      moddleElement: businessObject,
+      properties: {
+        cancelRemainingInstances: value
+      }
+    });
+  };
+
+  return CheckboxEntry({
+    element,
+    id: 'cancelRemainingInstances',
+    label: translate('Cancel Remaining Instances'),
+    getValue,
+    setValue,
+    description: translate('Whether to cancel remaining active tasks when completion condition is met')
+  });
+}
+
+
+// helper functions
+
+function createElement(type, properties, parent, bpmnFactory) {
+  const element = bpmnFactory.create(type, properties);
+
+  if (parent) {
+    element.$parent = parent;
+  }
+
+  return element;
+}
+
+function getExtensionElementsList(businessObject, type = undefined) {
+  const extensionElements = businessObject.get('extensionElements');
+
+  if (!extensionElements) {
+    return [];
+  }
+
+  const values = extensionElements.get('values');
+
+  if (!values || !values.length) {
+    return [];
+  }
+
+  if (type) {
+    return values.filter(value => is(value, type));
+  }
+
+  return values;
+}
+
+function getFluxnovaProperty(businessObject, propertyName) {
+  const fluxnovaProperties = getExtensionElementsList(businessObject, 'fluxnova:Properties')[0];
+
+  if (!fluxnovaProperties) {
+    return null;
+  }
+
+  const properties = fluxnovaProperties.get('values') || [];
+  return properties.find((p) => p.name === propertyName);
+}

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessProps.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessProps.js
@@ -204,7 +204,7 @@ function CompletionCondition(props) {
       if (!completionCondition) {
         // Create the Expression element
         completionCondition = createElement(
-          'bpmn:Expression',
+          'bpmn:FormalExpression',
           { body: value },
           businessObject,
           bpmnFactory

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessProps.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessProps.js
@@ -174,6 +174,11 @@ export function CompletionProps(props) {
       id: 'cancelRemainingInstances',
       component: CancelRemainingInstances,
       isEdited: isCheckboxEntryEdited
+    },
+    {
+      id: 'autoComplete',
+      component: AutoComplete,
+      isEdited: isCheckboxEntryEdited
     }
   ];
 
@@ -287,6 +292,127 @@ function CancelRemainingInstances(props) {
     getValue,
     setValue,
     description: translate('Whether to cancel remaining active tasks when completion condition is met')
+  });
+}
+
+function AutoComplete(props) {
+  const { element } = props;
+
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+  const bpmnFactory = useService('bpmnFactory');
+
+  const businessObject = getBusinessObject(element);
+
+  const getValue = () => {
+    const property = getFluxnovaProperty(businessObject, 'autoComplete');
+
+    if (!property) {
+      return true;
+    }
+
+    return property.value !== 'false';
+  };
+
+  const setValue = (value) => {
+    const commands = [];
+
+    let extensionElements = businessObject.get('extensionElements');
+    let fluxnovaProperties = getExtensionElementsList(businessObject, 'fluxnova:Properties')[0];
+    const autoCompleteProperty = fluxnovaProperties?.get('values')?.find((v) => v.name === 'autoComplete');
+
+    if (value === false) {
+      if (!extensionElements) {
+        extensionElements = createElement(
+          'bpmn:ExtensionElements',
+          { values: [] },
+          businessObject,
+          bpmnFactory
+        );
+
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: businessObject,
+            properties: { extensionElements }
+          }
+        });
+      }
+
+      if (!fluxnovaProperties) {
+        fluxnovaProperties = createElement(
+          'fluxnova:Properties',
+          { values: [] },
+          extensionElements,
+          bpmnFactory
+        );
+
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: extensionElements,
+            properties: {
+              values: [ ...extensionElements.get('values'), fluxnovaProperties ]
+            }
+          }
+        });
+      }
+
+      if (autoCompleteProperty) {
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: autoCompleteProperty,
+            properties: { value: 'false' }
+          }
+        });
+      } else {
+        const property = createElement(
+          'fluxnova:Property',
+          { name: 'autoComplete', value: 'false' },
+          fluxnovaProperties,
+          bpmnFactory
+        );
+
+        commands.push({
+          cmd: 'element.updateModdleProperties',
+          context: {
+            element,
+            moddleElement: fluxnovaProperties,
+            properties: {
+              values: [ ...(fluxnovaProperties.get('values') || []), property ]
+            }
+          }
+        });
+      }
+    } else if (autoCompleteProperty) {
+      commands.push({
+        cmd: 'element.updateModdleProperties',
+        context: {
+          element,
+          moddleElement: fluxnovaProperties,
+          properties: {
+            values: without(fluxnovaProperties.get('values'), autoCompleteProperty)
+          }
+        }
+      });
+    }
+
+    if (commands.length) {
+      commandStack.execute('properties-panel.multi-command-executor', commands);
+    }
+  };
+
+  return CheckboxEntry({
+    element,
+    id: 'autoComplete',
+    label: translate('Auto Complete'),
+    getValue,
+    setValue,
+    description: translate('Whether to automatically complete the ad hoc subprocess after initial activities are done')
   });
 }
 

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessProps.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/AdHocSubProcessProps.js
@@ -300,110 +300,23 @@ function AutoComplete(props) {
 
   const commandStack = useService('commandStack');
   const translate = useService('translate');
-  const bpmnFactory = useService('bpmnFactory');
 
   const businessObject = getBusinessObject(element);
 
   const getValue = () => {
-    const property = getFluxnovaProperty(businessObject, 'autoComplete');
-
-    if (!property) {
-      return true;
-    }
-
-    return property.value !== 'false';
+    const value = businessObject.get('autoComplete');
+    return isDefined(value) ? value : true;
   };
 
   const setValue = (value) => {
-    const commands = [];
-
-    let extensionElements = businessObject.get('extensionElements');
-    let fluxnovaProperties = getExtensionElementsList(businessObject, 'fluxnova:Properties')[0];
-    const autoCompleteProperty = fluxnovaProperties?.get('values')?.find((v) => v.name === 'autoComplete');
-
-    if (value === false) {
-      if (!extensionElements) {
-        extensionElements = createElement(
-          'bpmn:ExtensionElements',
-          { values: [] },
-          businessObject,
-          bpmnFactory
-        );
-
-        commands.push({
-          cmd: 'element.updateModdleProperties',
-          context: {
-            element,
-            moddleElement: businessObject,
-            properties: { extensionElements }
-          }
-        });
+    commandStack.execute('element.updateModdleProperties', {
+      element,
+      moddleElement: businessObject,
+      properties: {
+        // default=true, persist only when false
+        autoComplete: value === false ? false : undefined
       }
-
-      if (!fluxnovaProperties) {
-        fluxnovaProperties = createElement(
-          'fluxnova:Properties',
-          { values: [] },
-          extensionElements,
-          bpmnFactory
-        );
-
-        commands.push({
-          cmd: 'element.updateModdleProperties',
-          context: {
-            element,
-            moddleElement: extensionElements,
-            properties: {
-              values: [ ...extensionElements.get('values'), fluxnovaProperties ]
-            }
-          }
-        });
-      }
-
-      if (autoCompleteProperty) {
-        commands.push({
-          cmd: 'element.updateModdleProperties',
-          context: {
-            element,
-            moddleElement: autoCompleteProperty,
-            properties: { value: 'false' }
-          }
-        });
-      } else {
-        const property = createElement(
-          'fluxnova:Property',
-          { name: 'autoComplete', value: 'false' },
-          fluxnovaProperties,
-          bpmnFactory
-        );
-
-        commands.push({
-          cmd: 'element.updateModdleProperties',
-          context: {
-            element,
-            moddleElement: fluxnovaProperties,
-            properties: {
-              values: [ ...(fluxnovaProperties.get('values') || []), property ]
-            }
-          }
-        });
-      }
-    } else if (autoCompleteProperty) {
-      commands.push({
-        cmd: 'element.updateModdleProperties',
-        context: {
-          element,
-          moddleElement: fluxnovaProperties,
-          properties: {
-            values: without(fluxnovaProperties.get('values'), autoCompleteProperty)
-          }
-        }
-      });
-    }
-
-    if (commands.length) {
-      commandStack.execute('properties-panel.multi-command-executor', commands);
-    }
+    });
   };
 
   return CheckboxEntry({

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/__tests__/AdHocSubProcessGroupSpec.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/__tests__/AdHocSubProcessGroupSpec.js
@@ -85,7 +85,7 @@ describe('AdHocSubProcessGroup', function() {
     expect(hasActiveTasksEntry).to.be.true;
   });
 
-  it('should have completionCondition and cancelRemainingInstances in Completion group', function() {
+  it('should have completionCondition, cancelRemainingInstances and autoComplete in Completion group', function() {
 
     const element = {
       businessObject: {
@@ -100,5 +100,6 @@ describe('AdHocSubProcessGroup', function() {
 
     expect(entryIds).to.include('completionCondition');
     expect(entryIds).to.include('cancelRemainingInstances');
+    expect(entryIds).to.include('autoComplete');
   });
 });

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/__tests__/AdHocSubProcessGroupSpec.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/__tests__/AdHocSubProcessGroupSpec.js
@@ -1,0 +1,104 @@
+import { expect } from 'chai';
+import { createAdHocSubProcessGroups } from '../AdHocSubProcessGroup';
+
+describe('AdHocSubProcessGroup', function() {
+
+  it('should return array with two groups when element is AdHocSubProcess', function() {
+
+    const element = {
+      businessObject: {
+        $type: 'bpmn:AdHocSubProcess',
+        $instanceOf: (type) => type === 'bpmn:AdHocSubProcess'
+      }
+    };
+
+    const groups = createAdHocSubProcessGroups(element);
+
+    expect(groups).to.be.an('array').with.lengthOf(2);
+    expect(groups[0].id).to.equal('ad_hoc_subprocess_active_tasks');
+    expect(groups[1].id).to.equal('ad_hoc_subprocess_completion');
+  });
+
+  it('should return empty array when element is not AdHocSubProcess', function() {
+
+    const element = {
+      businessObject: {
+        $type: 'bpmn:SubProcess',
+        $instanceOf: (type) => type === 'bpmn:SubProcess'
+      }
+    };
+
+    const groups = createAdHocSubProcessGroups(element);
+
+    expect(groups).to.be.an('array').that.is.empty;
+  });
+
+  it('should have correct Active Tasks group properties', function() {
+
+    const element = {
+      businessObject: {
+        $type: 'bpmn:AdHocSubProcess',
+        $instanceOf: (type) => type === 'bpmn:AdHocSubProcess'
+      }
+    };
+
+    const groups = createAdHocSubProcessGroups(element);
+    const activeTasksGroup = groups[0];
+
+    expect(activeTasksGroup).to.have.property('id', 'ad_hoc_subprocess_active_tasks');
+    expect(activeTasksGroup).to.have.property('label', 'Active Tasks');
+    expect(activeTasksGroup).to.have.property('entries');
+    expect(activeTasksGroup.entries).to.be.an('array').with.length.greaterThan(0);
+  });
+
+  it('should have correct Completion group properties', function() {
+
+    const element = {
+      businessObject: {
+        $type: 'bpmn:AdHocSubProcess',
+        $instanceOf: (type) => type === 'bpmn:AdHocSubProcess'
+      }
+    };
+
+    const groups = createAdHocSubProcessGroups(element);
+    const completionGroup = groups[1];
+
+    expect(completionGroup).to.have.property('id', 'ad_hoc_subprocess_completion');
+    expect(completionGroup).to.have.property('label', 'Completion');
+    expect(completionGroup).to.have.property('entries');
+    expect(completionGroup.entries).to.be.an('array').with.length.greaterThan(0);
+  });
+
+  it('should have activeTasksCollection entry in Active Tasks group', function() {
+
+    const element = {
+      businessObject: {
+        $type: 'bpmn:AdHocSubProcess',
+        $instanceOf: (type) => type === 'bpmn:AdHocSubProcess'
+      }
+    };
+
+    const groups = createAdHocSubProcessGroups(element);
+    const activeTasksGroup = groups[0];
+    const hasActiveTasksEntry = activeTasksGroup.entries.some(entry => entry.id === 'activeTasksCollection');
+
+    expect(hasActiveTasksEntry).to.be.true;
+  });
+
+  it('should have completionCondition and cancelRemainingInstances in Completion group', function() {
+
+    const element = {
+      businessObject: {
+        $type: 'bpmn:AdHocSubProcess',
+        $instanceOf: (type) => type === 'bpmn:AdHocSubProcess'
+      }
+    };
+
+    const groups = createAdHocSubProcessGroups(element);
+    const completionGroup = groups[1];
+    const entryIds = completionGroup.entries.map(entry => entry.id);
+
+    expect(entryIds).to.include('completionCondition');
+    expect(entryIds).to.include('cancelRemainingInstances');
+  });
+});

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/__tests__/AdHocSubProcessPropsSpec.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/__tests__/AdHocSubProcessPropsSpec.js
@@ -75,7 +75,7 @@ describe('AdHocSubProcessProps', function() {
       const props = { element };
       const result = CompletionProps(props);
 
-      expect(result).to.be.an('array').with.lengthOf(2);
+      expect(result).to.be.an('array').with.lengthOf(3);
     });
 
     it('should have completionCondition entry', function() {
@@ -114,6 +114,24 @@ describe('AdHocSubProcessProps', function() {
       expect(cancelEntry.isEdited).to.be.a('function');
     });
 
+    it('should have autoComplete entry', function() {
+      const element = {
+        businessObject: {
+          $type: 'bpmn:AdHocSubProcess',
+          $instanceOf: (type) => type === 'bpmn:AdHocSubProcess'
+        }
+      };
+      const props = { element };
+      const result = CompletionProps(props);
+      const autoCompleteEntry = result.find(entry => entry.id === 'autoComplete');
+
+      expect(autoCompleteEntry).to.exist;
+      expect(autoCompleteEntry).to.have.property('component');
+      expect(autoCompleteEntry.component).to.be.a('function');
+      expect(autoCompleteEntry).to.have.property('isEdited');
+      expect(autoCompleteEntry.isEdited).to.be.a('function');
+    });
+
     it('should return entries in correct order', function() {
       const element = {
         businessObject: {
@@ -127,6 +145,7 @@ describe('AdHocSubProcessProps', function() {
 
       expect(ids[0]).to.equal('completionCondition');
       expect(ids[1]).to.equal('cancelRemainingInstances');
+      expect(ids[2]).to.equal('autoComplete');
     });
   });
 });

--- a/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/__tests__/AdHocSubProcessPropsSpec.js
+++ b/client/src/app/tabs/bpmn/modeler/features/properties-panel-extension/props/__tests__/AdHocSubProcessPropsSpec.js
@@ -1,0 +1,132 @@
+import { expect } from 'chai';
+import { ActiveTasksCollectionProps, CompletionProps } from '../AdHocSubProcessProps';
+
+describe('AdHocSubProcessProps', function() {
+
+  describe('ActiveTasksCollectionProps', function() {
+
+    it('should return empty array for non-AdHocSubProcess elements', function() {
+      const element = {
+        businessObject: {
+          $type: 'bpmn:SubProcess',
+          $instanceOf: (type) => type === 'bpmn:SubProcess'
+        }
+      };
+      const props = { element };
+      const result = ActiveTasksCollectionProps(props);
+
+      expect(result).to.be.an('array').that.is.empty;
+    });
+
+    it('should return entry array for AdHocSubProcess elements', function() {
+      const element = {
+        businessObject: {
+          $type: 'bpmn:AdHocSubProcess',
+          $instanceOf: (type) => type === 'bpmn:AdHocSubProcess'
+        }
+      };
+      const props = { element };
+      const result = ActiveTasksCollectionProps(props);
+
+      expect(result).to.be.an('array').with.lengthOf(1);
+    });
+
+    it('should have correct entry structure', function() {
+      const element = {
+        businessObject: {
+          $type: 'bpmn:AdHocSubProcess',
+          $instanceOf: (type) => type === 'bpmn:AdHocSubProcess'
+        }
+      };
+      const props = { element };
+      const result = ActiveTasksCollectionProps(props);
+      const entry = result[0];
+
+      expect(entry).to.have.property('id', 'activeTasksCollection');
+      expect(entry).to.have.property('component');
+      expect(entry.component).to.be.a('function');
+      expect(entry).to.have.property('isEdited');
+      expect(entry.isEdited).to.be.a('function');
+    });
+  });
+
+  describe('CompletionProps', function() {
+
+    it('should return empty array for non-AdHocSubProcess elements', function() {
+      const element = {
+        businessObject: {
+          $type: 'bpmn:SubProcess',
+          $instanceOf: (type) => type === 'bpmn:SubProcess'
+        }
+      };
+      const props = { element };
+      const result = CompletionProps(props);
+
+      expect(result).to.be.an('array').that.is.empty;
+    });
+
+    it('should return entries array for AdHocSubProcess elements', function() {
+      const element = {
+        businessObject: {
+          $type: 'bpmn:AdHocSubProcess',
+          $instanceOf: (type) => type === 'bpmn:AdHocSubProcess'
+        }
+      };
+      const props = { element };
+      const result = CompletionProps(props);
+
+      expect(result).to.be.an('array').with.lengthOf(2);
+    });
+
+    it('should have completionCondition entry', function() {
+      const element = {
+        businessObject: {
+          $type: 'bpmn:AdHocSubProcess',
+          $instanceOf: (type) => type === 'bpmn:AdHocSubProcess'
+        }
+      };
+      const props = { element };
+      const result = CompletionProps(props);
+      const completionEntry = result.find(entry => entry.id === 'completionCondition');
+
+      expect(completionEntry).to.exist;
+      expect(completionEntry).to.have.property('component');
+      expect(completionEntry.component).to.be.a('function');
+      expect(completionEntry).to.have.property('isEdited');
+      expect(completionEntry.isEdited).to.be.a('function');
+    });
+
+    it('should have cancelRemainingInstances entry', function() {
+      const element = {
+        businessObject: {
+          $type: 'bpmn:AdHocSubProcess',
+          $instanceOf: (type) => type === 'bpmn:AdHocSubProcess'
+        }
+      };
+      const props = { element };
+      const result = CompletionProps(props);
+      const cancelEntry = result.find(entry => entry.id === 'cancelRemainingInstances');
+
+      expect(cancelEntry).to.exist;
+      expect(cancelEntry).to.have.property('component');
+      expect(cancelEntry.component).to.be.a('function');
+      expect(cancelEntry).to.have.property('isEdited');
+      expect(cancelEntry.isEdited).to.be.a('function');
+    });
+
+    it('should return entries in correct order', function() {
+      const element = {
+        businessObject: {
+          $type: 'bpmn:AdHocSubProcess',
+          $instanceOf: (type) => type === 'bpmn:AdHocSubProcess'
+        }
+      };
+      const props = { element };
+      const result = CompletionProps(props);
+      const ids = result.map(entry => entry.id);
+
+      expect(ids[0]).to.equal('completionCondition');
+      expect(ids[1]).to.equal('cancelRemainingInstances');
+    });
+  });
+});

--- a/client/src/moddle/fluxnova-bpmn-moddle.json
+++ b/client/src/moddle/fluxnova-bpmn-moddle.json
@@ -8,6 +8,20 @@
   "associations": [],
   "types": [
     {
+      "name": "AdHocSubProcess",
+      "isAbstract": true,
+      "extends": [
+        "bpmn:AdHocSubProcess"
+      ],
+      "properties": [
+        {
+          "name": "autoComplete",
+          "isAttr": true,
+          "type": "Boolean"
+        }
+      ]
+    },
+    {
       "name": "Properties",
       "superClass": ["Element"],
       "meta": {

--- a/client/src/moddle/fluxnova-bpmn-moddle.json
+++ b/client/src/moddle/fluxnova-bpmn-moddle.json
@@ -1,0 +1,45 @@
+{
+  "name": "Fluxnova",
+  "uri": "http://fluxnova.finos.org/schema/1.0/bpmn",
+  "prefix": "fluxnova",
+  "xml": {
+    "tagAlias": "lowerCase"
+  },
+  "associations": [],
+  "types": [
+    {
+      "name": "Properties",
+      "superClass": ["Element"],
+      "meta": {
+        "allowedIn": ["*"]
+      },
+      "properties": [
+        {
+          "name": "values",
+          "type": "Property",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "Property",
+      "superClass": ["Element"],
+      "meta": {
+        "allowedIn": ["*"]
+      },
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "value",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    }
+  ],
+  "enumerations": []
+}

--- a/client/src/util/__tests__/xmlConversionSpec.js
+++ b/client/src/util/__tests__/xmlConversionSpec.js
@@ -1,6 +1,9 @@
-import { toBpmnXml, toDmnXml } from '../xmlConversion';
+import { toBpmnXml, toDmnXml, getBpmnDefinitions } from '../xmlConversion';
 import BpmnModdle from 'bpmn-moddle';
 import DmnModdle from 'dmn-moddle';
+import FluxnovaBpmnModdle from '../../moddle/fluxnova-bpmn-moddle';
+import FluxnovaModelerModdle from '../../moddle/fluxnova-bpmn-modeler-moddle';
+import CamundaBpmnModdle from 'camunda-bpmn-moddle/resources/camunda';
 
 describe('util - xmlConversionSpec', function() {
 
@@ -40,6 +43,81 @@ describe('util - xmlConversionSpec', function() {
 
   });
 
+  describe('Ad Hoc SubProcess with Fluxnova extensions', function() {
 
+    const adHocSubProcessXml = '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"' +
+      '                   xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"' +
+      '                   xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"' +
+      '                   xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"' +
+      '                   id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">' +
+      '  <bpmn:process id="Process_1" isExecutable="true">' +
+      '    <bpmn:adHocSubProcess id="AdHocSubProcess_1" cancelRemainingInstances="true">' +
+      '      <bpmn:extensionElements>' +
+      '        <fluxnova:Properties>' +
+      '          <fluxnova:Property name="activeTasksCollection" value="taskA,taskB" />' +
+      '        </fluxnova:Properties>' +
+      '      </bpmn:extensionElements>' +
+      '      <bpmn:completionCondition xsi:type="bpmn:tFormalExpression"' +
+      '      <bpmn:completionCondition>' + '${approved == true}' + '</bpmn:completionCondition>' +
+      '      <bpmn:userTask id="taskA" name="Task A" />' +
+      '      <bpmn:userTask id="taskB" name="Task B" />' +
+      '    </bpmn:adHocSubProcess>' +
+      '  </bpmn:process>' +
+      '</bpmn:definitions>';
+
+    it('should parse and preserve fluxnova:properties with completionCondition', async function() {
+
+      const definitions = await getBpmnDefinitions(adHocSubProcessXml, 'bpmn');
+
+      const process = definitions.rootElements[0];
+      const adHocSubProcess = process.flowElements[0];
+
+      expect(adHocSubProcess.id).to.equal('AdHocSubProcess_1');
+      expect(adHocSubProcess.cancelRemainingInstances).to.equal(true);
+
+      // Verify fluxnova:Properties extension element exists
+      const extensionElements = adHocSubProcess.extensionElements;
+      expect(extensionElements).to.exist;
+
+      const fluxnovaProperties = extensionElements.values.find((v) => v.$type === 'fluxnova:Properties');
+      expect(fluxnovaProperties).to.exist;
+
+      const activeTasksProperty = fluxnovaProperties.values.find((p) => p.name === 'activeTasksCollection');
+      expect(activeTasksProperty).to.exist;
+      expect(activeTasksProperty.value).to.equal('taskA,taskB');
+
+      // Verify completionCondition expression exists
+      const completionCondition = adHocSubProcess.completionCondition;
+      expect(completionCondition).to.exist;
+      expect(completionCondition.body).to.include('approved');
+
+    });
+
+    it('should export and preserve fluxnova:properties', async function() {
+
+      // Use a single moddle instance for round-trip to ensure consistent serialization
+      const moddle = new BpmnModdle({
+        modeler: FluxnovaModelerModdle,
+        fluxnova: FluxnovaBpmnModdle,
+        camunda: CamundaBpmnModdle
+      });
+      const { rootElement: definitions } = await moddle.fromXML(adHocSubProcessXml);
+      const { xml } = await moddle.toXML(definitions, { format: true });
+
+      // Verify the exported XML contains fluxnova namespace and elements
+      expect(xml).to.contain('xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"');
+      // Debug: if above fails, log the actual XML
+      expect(xml).to.contain('fluxnova:properties');
+      expect(xml).to.contain('fluxnova:property');
+      expect(xml).to.contain('name="activeTasksCollection"');
+      expect(xml).to.contain('value="taskA,taskB"');
+
+      // Verify BPMN standard attributes are preserved
+      expect(xml).to.contain('completionCondition');
+
+    });
+
+  });
 
 });

--- a/client/src/util/__tests__/xmlConversionSpec.js
+++ b/client/src/util/__tests__/xmlConversionSpec.js
@@ -141,9 +141,40 @@ describe('util - xmlConversionSpec', function() {
       const extensionElements = adHocSubProcess.extensionElements;
       const fluxnovaProperties = extensionElements.values.find((v) => v.$type === 'fluxnova:Properties');
       const activeTasksProperty = fluxnovaProperties.values.find((p) => p.name === 'activeTasksCollection');
+      const autoCompleteProperty = fluxnovaProperties.values.find((p) => p.name === 'autoComplete');
 
       expect(activeTasksProperty).to.exist;
       expect(activeTasksProperty.value).to.equal('${taskList}');
+      expect(autoCompleteProperty).to.not.exist;
+    });
+
+    it('should parse autoComplete property when false', async function() {
+
+      const xmlWithAutoCompleteFalse = '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"' +
+        '                   xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"' +
+        '                   id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">' +
+        '  <bpmn:process id="Process_1" isExecutable="true">' +
+        '    <bpmn:adHocSubProcess id="AdHocSubProcess_1">' +
+        '      <bpmn:extensionElements>' +
+        '        <fluxnova:Properties>' +
+        '          <fluxnova:Property name="activeTasksCollection" value="taskA,taskB" />' +
+        '          <fluxnova:Property name="autoComplete" value="false" />' +
+        '        </fluxnova:Properties>' +
+        '      </bpmn:extensionElements>' +
+        '    </bpmn:adHocSubProcess>' +
+        '  </bpmn:process>' +
+        '</bpmn:definitions>';
+
+      const definitions = await getBpmnDefinitions(xmlWithAutoCompleteFalse, 'bpmn');
+      const adHocSubProcess = definitions.rootElements[0].flowElements[0];
+
+      const extensionElements = adHocSubProcess.extensionElements;
+      const fluxnovaProperties = extensionElements.values.find((v) => v.$type === 'fluxnova:Properties');
+      const autoCompleteProperty = fluxnovaProperties.values.find((p) => p.name === 'autoComplete');
+
+      expect(autoCompleteProperty).to.exist;
+      expect(autoCompleteProperty.value).to.equal('false');
     });
 
     it('should parse completionCondition only', async function() {
@@ -209,6 +240,36 @@ describe('util - xmlConversionSpec', function() {
 
       expect(xml).to.contain('name="activeTasksCollection"');
       expect(xml).to.contain('value="task1,task2,task3"');
+      expect(xml).to.not.contain('name="autoComplete"');
+    });
+
+    it('should export autoComplete property when false', async function() {
+
+      const xmlWithAutoCompleteFalse = '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"' +
+        '                   xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"' +
+        '                   id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">' +
+        '  <bpmn:process id="Process_1" isExecutable="true">' +
+        '    <bpmn:adHocSubProcess id="AdHocSubProcess_1">' +
+        '      <bpmn:extensionElements>' +
+        '        <fluxnova:Properties>' +
+        '          <fluxnova:Property name="activeTasksCollection" value="taskA,taskB" />' +
+        '          <fluxnova:Property name="autoComplete" value="false" />' +
+        '        </fluxnova:Properties>' +
+        '      </bpmn:extensionElements>' +
+        '    </bpmn:adHocSubProcess>' +
+        '  </bpmn:process>' +
+        '</bpmn:definitions>';
+
+      const moddle = new BpmnModdle({
+        fluxnova: FluxnovaBpmnModdle,
+        modeler: FluxnovaModelerModdle
+      });
+      const { rootElement: definitions } = await moddle.fromXML(xmlWithAutoCompleteFalse);
+      const { xml } = await moddle.toXML(definitions, { format: true });
+
+      expect(xml).to.contain('name="autoComplete"');
+      expect(xml).to.contain('value="false"');
     });
 
     it('should handle AdHocSubProcess with no Fluxnova properties', async function() {

--- a/client/src/util/__tests__/xmlConversionSpec.js
+++ b/client/src/util/__tests__/xmlConversionSpec.js
@@ -118,6 +118,167 @@ describe('util - xmlConversionSpec', function() {
 
     });
 
+    it('should parse activeTasksCollection property only', async function() {
+
+      const xmlOnlyActiveTasksCollection = '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"' +
+        '                   xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"' +
+        '                   id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">' +
+        '  <bpmn:process id="Process_1" isExecutable="true">' +
+        '    <bpmn:adHocSubProcess id="AdHocSubProcess_1">' +
+        '      <bpmn:extensionElements>' +
+        '        <fluxnova:Properties>' +
+        '          <fluxnova:Property name="activeTasksCollection" value="${taskList}" />' +
+        '        </fluxnova:Properties>' +
+        '      </bpmn:extensionElements>' +
+        '    </bpmn:adHocSubProcess>' +
+        '  </bpmn:process>' +
+        '</bpmn:definitions>';
+
+      const definitions = await getBpmnDefinitions(xmlOnlyActiveTasksCollection, 'bpmn');
+      const adHocSubProcess = definitions.rootElements[0].flowElements[0];
+
+      const extensionElements = adHocSubProcess.extensionElements;
+      const fluxnovaProperties = extensionElements.values.find((v) => v.$type === 'fluxnova:Properties');
+      const activeTasksProperty = fluxnovaProperties.values.find((p) => p.name === 'activeTasksCollection');
+
+      expect(activeTasksProperty).to.exist;
+      expect(activeTasksProperty.value).to.equal('${taskList}');
+    });
+
+    it('should parse completionCondition only', async function() {
+
+      const xmlOnlyCompletionCondition = '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"' +
+        '                   id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">' +
+        '  <bpmn:process id="Process_1" isExecutable="true">' +
+        '    <bpmn:adHocSubProcess id="AdHocSubProcess_1">' +
+        '      <bpmn:completionCondition>${allTasksComplete}</bpmn:completionCondition>' +
+        '    </bpmn:adHocSubProcess>' +
+        '  </bpmn:process>' +
+        '</bpmn:definitions>';
+
+      const definitions = await getBpmnDefinitions(xmlOnlyCompletionCondition, 'bpmn');
+      const adHocSubProcess = definitions.rootElements[0].flowElements[0];
+
+      const completionCondition = adHocSubProcess.completionCondition;
+      expect(completionCondition).to.exist;
+      expect(completionCondition.body).to.equal('${allTasksComplete}');
+    });
+
+    it('should parse cancelRemainingInstances attribute', async function() {
+
+      const xmlWithCancelRemainingInstances = '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"' +
+        '                   id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">' +
+        '  <bpmn:process id="Process_1" isExecutable="true">' +
+        '    <bpmn:adHocSubProcess id="AdHocSubProcess_1" cancelRemainingInstances="false">' +
+        '    </bpmn:adHocSubProcess>' +
+        '  </bpmn:process>' +
+        '</bpmn:definitions>';
+
+      const definitions = await getBpmnDefinitions(xmlWithCancelRemainingInstances, 'bpmn');
+      const adHocSubProcess = definitions.rootElements[0].flowElements[0];
+
+      expect(adHocSubProcess.cancelRemainingInstances).to.equal(false);
+    });
+
+    it('should export activeTasksCollection with expression values', async function() {
+
+      const xmlWithExpressions = '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"' +
+        '                   xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"' +
+        '                   id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">' +
+        '  <bpmn:process id="Process_1" isExecutable="true">' +
+        '    <bpmn:adHocSubProcess id="AdHocSubProcess_1">' +
+        '      <bpmn:extensionElements>' +
+        '        <fluxnova:Properties>' +
+        '          <fluxnova:Property name="activeTasksCollection" value="task1,task2,task3" />' +
+        '        </fluxnova:Properties>' +
+        '      </bpmn:extensionElements>' +
+        '    </bpmn:adHocSubProcess>' +
+        '  </bpmn:process>' +
+        '</bpmn:definitions>';
+
+      const moddle = new BpmnModdle({
+        fluxnova: FluxnovaBpmnModdle,
+        modeler: FluxnovaModelerModdle
+      });
+      const { rootElement: definitions } = await moddle.fromXML(xmlWithExpressions);
+      const { xml } = await moddle.toXML(definitions, { format: true });
+
+      expect(xml).to.contain('name="activeTasksCollection"');
+      expect(xml).to.contain('value="task1,task2,task3"');
+    });
+
+    it('should handle AdHocSubProcess with no Fluxnova properties', async function() {
+
+      const plainAdHocSubProcessXml = '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"' +
+        '                   id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">' +
+        '  <bpmn:process id="Process_1" isExecutable="true">' +
+        '    <bpmn:adHocSubProcess id="AdHocSubProcess_1" />' +
+        '  </bpmn:process>' +
+        '</bpmn:definitions>';
+
+      const definitions = await getBpmnDefinitions(plainAdHocSubProcessXml, 'bpmn');
+      const adHocSubProcess = definitions.rootElements[0].flowElements[0];
+
+      expect(adHocSubProcess.id).to.equal('AdHocSubProcess_1');
+      expect(adHocSubProcess.extensionElements).to.not.exist;
+    });
+
+    it('should handle AdHocSubProcess with multiple properties', async function() {
+
+      const xmlMultipleProperties = '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"' +
+        '                   xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"' +
+        '                   id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">' +
+        '  <bpmn:process id="Process_1" isExecutable="true">' +
+        '    <bpmn:adHocSubProcess id="AdHocSubProcess_1" cancelRemainingInstances="true">' +
+        '      <bpmn:extensionElements>' +
+        '        <fluxnova:Properties>' +
+        '          <fluxnova:Property name="activeTasksCollection" value="taskA,taskB" />' +
+        '          <fluxnova:Property name="otherProperty" value="someValue" />' +
+        '        </fluxnova:Properties>' +
+        '      </bpmn:extensionElements>' +
+        '      <bpmn:completionCondition>${completed}</bpmn:completionCondition>' +
+        '    </bpmn:adHocSubProcess>' +
+        '  </bpmn:process>' +
+        '</bpmn:definitions>';
+
+      const definitions = await getBpmnDefinitions(xmlMultipleProperties, 'bpmn');
+      const adHocSubProcess = definitions.rootElements[0].flowElements[0];
+
+      expect(adHocSubProcess.extensionElements).to.exist;
+      const fluxnovaProperties = adHocSubProcess.extensionElements.values.find((v) => v.$type === 'fluxnova:Properties');
+      expect(fluxnovaProperties.values).to.have.length.greaterThan(0);
+      expect(fluxnovaProperties.values.some(p => p.name === 'activeTasksCollection')).to.be.true;
+      expect(fluxnovaProperties.values.some(p => p.name === 'otherProperty')).to.be.true;
+    });
+
+    it('should round-trip completionCondition with complex expressions', async function() {
+
+      const xmlComplexExpression = '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"' +
+        '                   id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">' +
+        '  <bpmn:process id="Process_1" isExecutable="true">' +
+        '    <bpmn:adHocSubProcess id="AdHocSubProcess_1">' +
+        '      <bpmn:completionCondition>${count >= threshold &amp;&amp; approved == true}</bpmn:completionCondition>' +
+        '    </bpmn:adHocSubProcess>' +
+        '  </bpmn:process>' +
+        '</bpmn:definitions>';
+
+      const moddle = new BpmnModdle();
+      const { rootElement: definitions } = await moddle.fromXML(xmlComplexExpression);
+      const { xml: exportedXml } = await moddle.toXML(definitions, { format: true });
+
+      const adHocSubProcess = definitions.rootElements[0].flowElements[0];
+      expect(adHocSubProcess.completionCondition.body).to.include('count >= threshold');
+      expect(adHocSubProcess.completionCondition.body).to.include('approved == true');
+      expect(exportedXml).to.contain('completionCondition');
+    });
+
   });
 
 });

--- a/client/src/util/__tests__/xmlConversionSpec.js
+++ b/client/src/util/__tests__/xmlConversionSpec.js
@@ -148,18 +148,17 @@ describe('util - xmlConversionSpec', function() {
       expect(autoCompleteProperty).to.not.exist;
     });
 
-    it('should parse autoComplete property when false', async function() {
+    it('should parse autoComplete attribute when false', async function() {
 
       const xmlWithAutoCompleteFalse = '<?xml version="1.0" encoding="UTF-8"?>' +
         '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"' +
         '                   xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"' +
         '                   id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">' +
         '  <bpmn:process id="Process_1" isExecutable="true">' +
-        '    <bpmn:adHocSubProcess id="AdHocSubProcess_1">' +
+        '    <bpmn:adHocSubProcess id="AdHocSubProcess_1" fluxnova:autoComplete="false">' +
         '      <bpmn:extensionElements>' +
         '        <fluxnova:Properties>' +
         '          <fluxnova:Property name="activeTasksCollection" value="taskA,taskB" />' +
-        '          <fluxnova:Property name="autoComplete" value="false" />' +
         '        </fluxnova:Properties>' +
         '      </bpmn:extensionElements>' +
         '    </bpmn:adHocSubProcess>' +
@@ -169,12 +168,7 @@ describe('util - xmlConversionSpec', function() {
       const definitions = await getBpmnDefinitions(xmlWithAutoCompleteFalse, 'bpmn');
       const adHocSubProcess = definitions.rootElements[0].flowElements[0];
 
-      const extensionElements = adHocSubProcess.extensionElements;
-      const fluxnovaProperties = extensionElements.values.find((v) => v.$type === 'fluxnova:Properties');
-      const autoCompleteProperty = fluxnovaProperties.values.find((p) => p.name === 'autoComplete');
-
-      expect(autoCompleteProperty).to.exist;
-      expect(autoCompleteProperty.value).to.equal('false');
+      expect(adHocSubProcess.autoComplete).to.equal(false);
     });
 
     it('should parse completionCondition only', async function() {
@@ -240,21 +234,20 @@ describe('util - xmlConversionSpec', function() {
 
       expect(xml).to.contain('name="activeTasksCollection"');
       expect(xml).to.contain('value="task1,task2,task3"');
-      expect(xml).to.not.contain('name="autoComplete"');
+      expect(xml).to.not.contain('fluxnova:autoComplete=');
     });
 
-    it('should export autoComplete property when false', async function() {
+    it('should export autoComplete attribute when false', async function() {
 
       const xmlWithAutoCompleteFalse = '<?xml version="1.0" encoding="UTF-8"?>' +
         '<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"' +
         '                   xmlns:fluxnova="http://fluxnova.finos.org/schema/1.0/bpmn"' +
         '                   id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">' +
         '  <bpmn:process id="Process_1" isExecutable="true">' +
-        '    <bpmn:adHocSubProcess id="AdHocSubProcess_1">' +
+        '    <bpmn:adHocSubProcess id="AdHocSubProcess_1" fluxnova:autoComplete="false">' +
         '      <bpmn:extensionElements>' +
         '        <fluxnova:Properties>' +
         '          <fluxnova:Property name="activeTasksCollection" value="taskA,taskB" />' +
-        '          <fluxnova:Property name="autoComplete" value="false" />' +
         '        </fluxnova:Properties>' +
         '      </bpmn:extensionElements>' +
         '    </bpmn:adHocSubProcess>' +
@@ -268,8 +261,8 @@ describe('util - xmlConversionSpec', function() {
       const { rootElement: definitions } = await moddle.fromXML(xmlWithAutoCompleteFalse);
       const { xml } = await moddle.toXML(definitions, { format: true });
 
-      expect(xml).to.contain('name="autoComplete"');
-      expect(xml).to.contain('value="false"');
+      expect(xml).to.contain('fluxnova:autoComplete="false"');
+      expect(xml).to.not.contain('name="autoComplete"');
     });
 
     it('should handle AdHocSubProcess with no Fluxnova properties', async function() {

--- a/client/src/util/xmlConversion.js
+++ b/client/src/util/xmlConversion.js
@@ -42,10 +42,14 @@ export async function getDmnDefinitionsForConversion(xml) {
 
 export async function getBpmnDefinitions(xml, diagramType, modelerModdle = FluxnovaModelerModdle) {
 
-  const extensions = {
-    modeler: modelerModdle,
-    fluxnova: FluxnovaBpmnModdle
-  };
+  const extensions = {};
+
+  // Conversion path passes modelerModdle = null and should not force custom
+  // namespace registration. Runtime/editor paths use the default moddle.
+  if (modelerModdle) {
+    extensions.modeler = modelerModdle;
+    extensions.fluxnova = FluxnovaBpmnModdle;
+  }
 
   if (diagramType === 'bpmn') {
     extensions.camunda = CamundaBpmnModdle;
@@ -165,7 +169,6 @@ export function parseFormFieldCounts(contents) {
 export async function toBpmnXml(definitions) {
   const extensions = {
     camunda: CamundaBpmnModdle,
-    modeler: FluxnovaModelerModdle,
     fluxnova: FluxnovaBpmnModdle
   };
 

--- a/client/src/util/xmlConversion.js
+++ b/client/src/util/xmlConversion.js
@@ -17,6 +17,7 @@ import CamundaBpmnModdle from 'camunda-bpmn-moddle/resources/camunda';
 import CamundaDmnModdle from 'camunda-dmn-moddle/resources/camunda';
 import ZeebeBpmnModdle from 'zeebe-bpmn-moddle/resources/zeebe';
 import FluxnovaModelerModdle from '../moddle/fluxnova-bpmn-modeler-moddle';
+import FluxnovaBpmnModdle from '../moddle/fluxnova-bpmn-moddle';
 
 import { selfAndAllFlowElements } from './elementsUtil';
 import parseExecutionPlatform from '../app/util/parseExecutionPlatform';
@@ -42,7 +43,8 @@ export async function getDmnDefinitionsForConversion(xml) {
 export async function getBpmnDefinitions(xml, diagramType, modelerModdle = FluxnovaModelerModdle) {
 
   const extensions = {
-    modeler: modelerModdle
+    modeler: modelerModdle,
+    fluxnova: FluxnovaBpmnModdle
   };
 
   if (diagramType === 'bpmn') {
@@ -162,7 +164,9 @@ export function parseFormFieldCounts(contents) {
 
 export async function toBpmnXml(definitions) {
   const extensions = {
-    camunda: CamundaBpmnModdle
+    camunda: CamundaBpmnModdle,
+    modeler: FluxnovaModelerModdle,
+    fluxnova: FluxnovaBpmnModdle
   };
 
   const moddle = new BpmnModdle(extensions);


### PR DESCRIPTION
### Proposed Changes

This PR introduces the following properties to the ad-hoc subprocess properties panel to support engine side ad-hoc subprocess functionality.

Active Tasks Collection - the task to execute in the ad-hoc subprocess
Completion Condition - optional condition for exiting ad hoc subprocess
Cancel Remaining Instances - attribute specifying whether to wait for running tasks if completion condition is met

<img width="773" height="641" alt="Screenshot 2026-05-13 at 12 36 41 PM" src="https://github.com/user-attachments/assets/b037ea18-ea2c-496f-96e3-3e94f7866c51" />

Related to https://github.com/finos/fluxnova-bpm-platform/issues/168

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] __Brief textual description__ of the changes present
* [ ] __Visual demo__ attached
* [ ] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
