### PR TITLE
fix the tab state bug that always marked as dirty

### DIFF
--- a/client/src/app/tabs/dmn/DmnEditor.js
+++ b/client/src/app/tabs/dmn/DmnEditor.js
@@ -217,12 +217,11 @@ export class DmnEditor extends CachedComponent {
 
   isDirty = () => {
     let {
-      dirty,
       modeler,
       stackIdx
     } = this.getCached();
 
-    return dirty || modeler.getStackIdx() !== stackIdx;
+    return modeler.getStackIdx() !== stackIdx;
   };
 
   viewContentChanged = () => {

--- a/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/dmn/__tests__/DmnEditorSpec.js
@@ -545,6 +545,7 @@ describe('<DmnEditor>', function() {
 
       cache.add('editor', {
         cached: {
+          activeView: { element: undefined, type: 'drd' },
           lastXML: diagramXML,
           modeler: new DmnModeler({
             commandStack: {


### PR DESCRIPTION
fixes #92 

### Proposed Changes

When using the Fluxnova Modeler 1.2.0 with DMNs and introducing changes and reverting them, the tab state is incorrect. After we undo/revert the change through the "Edit" menu (do not use Cmd + Z shortcut because it has its own bug), the tab is still marked "dirty" even though it already reverts back to the "clean" state. 

This is due to the isDirty function in the DmnEditor.js:

```
  isDirty = () => {
    let {
      dirty,
      modeler,
      stackIdx
    } = this.getCached();

    return dirty || modeler.getStackIdx() !== stackIdx;
  };


handleChanged = () => {
....
    const dirty = this.isDirty();
....
}

```

The value of dirty is assigned by the isDirty function. After users make some changes, the condition "modeler.getStackIdx() !== stackIdx" will be true, so isDirty() returns true and gives it to dirty. 

Dirty itself is a condition in isDirty()'s OR statement. Since dirty = true, this function always returns true, making the tab state alway be marked as "dirty". 

To fix this bug, just remove dirty from the OR statement.

```
  isDirty = () => {
    let {
      modeler,
      stackIdx
    } = this.getCached();

    return modeler.getStackIdx() !== stackIdx;
  };
```

This change makes one test fails in DmnEditorSpec.js. In test case "should notify about changes", it expects dirty always to be true. But it doesn't add activeView in the cache, so in some situations cached.stackIdx is matched with the modeler's getStackIdx(). So isDirty() returns false. Previously this is not an issue, because dirty is a condition in isDirty() and it always return true. 

To fix this, I added activeView in the cache. 
