### PR TITLE
Upgrade protobufjs and update third party notices and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to the [Fluxnova Modeler](https://github.com/finos/fluxnova-
 
 **\_Note:** Yet to be released changes appear here.\_
 
+## 1.3.0
+
+- Updated react, react-dom, react-test-renderer from 16.14.0 to 18.3.1
+- Updated formik from 2.0.4 to 2.4.9
+- Updated electron from 37.0.0 to 42.3.3
+- Updated electron-extension-installer from 1.2.0 to 2.0.0
+- Migrated tests to @testing-library/react and removed enzyme dependency
+- Refactored Windows code signing logic to utilize Azure trusted signing
+- Fixed DMN tab state that was always marked as dirty
+- Add support for 3.0.0 execution platform version
+
 ## 1.2.0
 
 - Added retry time cycle functionality for element templates

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -5,357 +5,359 @@ Do Not Translate or Localize
 
 This project incorporates components from the projects listed below. The original copyright notices and the licenses under which Camunda received such components are set forth below.
 
-1.    @sentry/node@9.0.0 (git://github.com/getsentry/sentry-javascript.git)
-2.    @opentelemetry/api@1.9.0 (open-telemetry/opentelemetry-js)
-3.    @opentelemetry/instrumentation-http@0.57.1 (open-telemetry/opentelemetry-js)
+1.    @sentry/node@9.47.1 (git://github.com/getsentry/sentry-javascript.git)
+2.    @opentelemetry/api@1.9.1 (open-telemetry/opentelemetry-js)
+3.    @opentelemetry/instrumentation-http@0.57.2 (open-telemetry/opentelemetry-js)
 4.    @opentelemetry/core@1.30.1 (open-telemetry/opentelemetry-js)
 5.    @opentelemetry/semantic-conventions@1.28.0 (open-telemetry/opentelemetry-js)
-6.    semver@7.6.2 (git+https://github.com/npm/node-semver.git)
-7.    @opentelemetry/instrumentation@0.57.1 (git+https://github.com/open-telemetry/opentelemetry-js.git)
-8.    @opentelemetry/api-logs@0.57.1 (open-telemetry/opentelemetry-js)
+6.    semver@7.7.4 (git+https://github.com/npm/node-semver.git)
+7.    @opentelemetry/instrumentation@0.57.2 (git+https://github.com/open-telemetry/opentelemetry-js.git)
+8.    @opentelemetry/api-logs@0.57.2 (open-telemetry/opentelemetry-js)
 9.    shimmer@1.2.1 (https://github.com/othiym23/shimmer.git)
-10.   require-in-the-middle@7.3.0 (git+https://github.com/elastic/require-in-the-middle.git)
-11.   resolve@1.22.11 (ssh://github.com/browserify/resolve.git)
-12.   path-parse@1.0.7 (https://github.com/jbgutierrez/path-parse.git)
-13.   is-core-module@2.16.1 (git+https://github.com/inspect-js/is-core-module.git)
-14.   hasown@2.0.2 (git+https://github.com/inspect-js/hasOwn.git)
-15.   function-bind@1.1.2 (https://github.com/Raynos/function-bind.git)
-16.   debug@4.3.7 (git://github.com/debug-js/debug.git)
-17.   ms@2.1.3 (vercel/ms)
-18.   supports-color@5.5.0 (chalk/supports-color)
-19.   has-flag@3.0.0 (sindresorhus/has-flag)
-20.   module-details-from-path@1.0.3 (git+https://github.com/watson/module-details-from-path.git)
-21.   import-in-the-middle@1.13.0 (git+ssh://git@github.com/nodejs/import-in-the-middle.git)
-22.   forwarded-parse@2.1.2 (lpinca/forwarded-parse)
-23.   @sentry/core@9.0.0 (git://github.com/getsentry/sentry-javascript.git)
-24.   @opentelemetry/instrumentation-undici@0.10.0 (open-telemetry/opentelemetry-js-contrib)
-25.   @sentry/opentelemetry@9.0.0 (git://github.com/getsentry/sentry-javascript.git)
-26.   @opentelemetry/sdk-trace-base@1.30.1 (open-telemetry/opentelemetry-js)
-27.   @opentelemetry/resources@1.30.1 (open-telemetry/opentelemetry-js)
-28.   @opentelemetry/instrumentation-fs@0.19.0 (open-telemetry/opentelemetry-js-contrib)
-29.   @opentelemetry/instrumentation-express@0.47.0 (open-telemetry/opentelemetry-js-contrib)
-30.   @opentelemetry/instrumentation-fastify@0.44.1 (open-telemetry/opentelemetry-js-contrib)
-31.   @opentelemetry/instrumentation-graphql@0.47.0 (open-telemetry/opentelemetry-js-contrib)
-32.   @opentelemetry/instrumentation-kafkajs@0.7.0 (open-telemetry/opentelemetry-js-contrib)
-33.   @opentelemetry/instrumentation-lru-memoizer@0.44.0 (open-telemetry/opentelemetry-js-contrib)
-34.   @opentelemetry/instrumentation-mongodb@0.51.0 (open-telemetry/opentelemetry-js-contrib)
-35.   @opentelemetry/instrumentation-mongoose@0.46.0 (open-telemetry/opentelemetry-js-contrib)
-36.   @opentelemetry/instrumentation-mysql@0.45.0 (open-telemetry/opentelemetry-js-contrib)
-37.   @opentelemetry/instrumentation-mysql2@0.45.0 (open-telemetry/opentelemetry-js-contrib)
-38.   @opentelemetry/sql-common@0.40.1 (open-telemetry/opentelemetry-js-contrib)
-39.   @opentelemetry/instrumentation-ioredis@0.47.0 (open-telemetry/opentelemetry-js-contrib)
-40.   @opentelemetry/redis-common@0.36.2 (open-telemetry/opentelemetry-js-contrib)
-41.   @opentelemetry/instrumentation-redis-4@0.46.0 (open-telemetry/opentelemetry-js-contrib)
-42.   @opentelemetry/instrumentation-pg@0.50.0 (open-telemetry/opentelemetry-js-contrib)
-43.   @prisma/instrumentation@6.2.1 (https://github.com/prisma/prisma.git)
-44.   @opentelemetry/instrumentation-hapi@0.45.1 (open-telemetry/opentelemetry-js-contrib)
-45.   @opentelemetry/instrumentation-koa@0.47.0 (open-telemetry/opentelemetry-js-contrib)
-46.   @opentelemetry/instrumentation-connect@0.43.0 (open-telemetry/opentelemetry-js-contrib)
-47.   @opentelemetry/instrumentation-knex@0.44.0 (open-telemetry/opentelemetry-js-contrib)
-48.   @opentelemetry/instrumentation-tedious@0.18.0 (open-telemetry/opentelemetry-js-contrib)
-49.   @opentelemetry/instrumentation-generic-pool@0.43.0 (open-telemetry/opentelemetry-js-contrib)
-50.   @opentelemetry/instrumentation-dataloader@0.16.0 (open-telemetry/opentelemetry-js-contrib)
-51.   @opentelemetry/instrumentation-amqplib@0.46.0 (open-telemetry/opentelemetry-js-contrib)
-52.   @opentelemetry/context-async-hooks@1.30.1 (open-telemetry/opentelemetry-js)
-53.   @camunda8/sdk@8.8.7 (git+https://github.com/camunda/camunda-8-js-sdk.git)
-54.   got@11.8.6 (sindresorhus/got)
-55.   @sindresorhus/is@4.6.0 (sindresorhus/is)
-56.   p-cancelable@2.1.1 (sindresorhus/p-cancelable)
-57.   @szmarczak/http-timer@4.0.6 (git+https://github.com/szmarczak/http-timer.git)
-58.   defer-to-connect@2.0.1 (git+https://github.com/szmarczak/defer-to-connect.git)
-59.   cacheable-lookup@5.0.4 (git+https://github.com/szmarczak/cacheable-lookup.git)
-60.   cacheable-request@7.0.2 (lukechilds/cacheable-request)
-61.   normalize-url@6.1.0 (sindresorhus/normalize-url)
-62.   get-stream@5.2.0 (sindresorhus/get-stream)
-63.   pump@3.0.0 (git://github.com/mafintosh/pump.git)
-64.   once@1.4.0 (git://github.com/isaacs/once)
-65.   wrappy@1.0.2 (https://github.com/npm/wrappy)
-66.   end-of-stream@1.4.1 (git://github.com/mafintosh/end-of-stream.git)
-67.   http-cache-semantics@4.1.1 (https://github.com/kornelski/http-cache-semantics.git)
-68.   responselike@2.0.1 (https://github.com/sindresorhus/responselike.git)
-69.   lowercase-keys@2.0.0 (sindresorhus/lowercase-keys)
-70.   clone-response@1.0.3 (git+https://github.com/sindresorhus/clone-response.git)
-71.   mimic-response@1.0.1 (sindresorhus/mimic-response)
-72.   keyv@4.5.4 (git+https://github.com/jaredwray/keyv.git)
-73.   json-buffer@3.0.1 (git://github.com/dominictarr/json-buffer.git)
-74.   decompress-response@6.0.0 (sindresorhus/decompress-response)
-75.   http2-wrapper@1.0.3 (git+https://github.com/szmarczak/http2-wrapper.git)
-76.   quick-lru@5.1.1 (sindresorhus/quick-lru)
-77.   resolve-alpn@1.2.1 (git+https://github.com/szmarczak/resolve-alpn.git)
-78.   lodash.mergewith@4.6.2 (lodash/lodash)
-79.   typed-env@2.0.0 (git+https://github.com/itslukej/typed-env.git)
-80.   jwt-decode@4.0.0 (git://github.com/auth0/jwt-decode)
-81.   winston@3.17.0 (https://github.com/winstonjs/winston.git)
-82.   logform@2.7.0 (git+https://github.com/winstonjs/logform.git)
-83.   @colors/colors@1.6.0 (http://github.com/DABH/colors.js.git)
-84.   triple-beam@1.4.1 (git+https://github.com/winstonjs/triple-beam.git)
-85.   safe-stable-stringify@2.5.0 (git+https://github.com/BridgeAR/safe-stable-stringify.git)
-86.   fecha@4.2.3 (https://taylorhakes@github.com/taylorhakes/fecha.git)
-87.   winston-transport@4.9.0 (git@github.com:winstonjs/winston-transport.git)
-88.   readable-stream@3.6.2 (git://github.com/nodejs/readable-stream)
-89.   util-deprecate@1.0.2 (git://github.com/TooTallNate/util-deprecate.git)
-90.   inherits@2.0.4 (git://github.com/isaacs/inherits)
-91.   string_decoder@1.3.0 (git://github.com/nodejs/string_decoder.git)
-92.   safe-buffer@5.2.1 (git://github.com/feross/safe-buffer.git)
-93.   async@3.2.6 (https://github.com/caolan/async.git)
-94.   @dabh/diagnostics@2.0.3 (git://github.com/3rd-Eden/diagnostics.git)
-95.   colorspace@1.1.4 (https://github.com/3rd-Eden/colorspace)
-96.   color@3.2.1 (Qix-/color)
-97.   color-string@1.9.1 (Qix-/color-string)
-98.   color-name@1.1.3 (git@github.com:dfcreative/color-name.git)
-99.   simple-swizzle@0.2.2 (qix-/node-simple-swizzle)
-100.  is-arrayish@0.3.2 (https://github.com/qix-/node-is-arrayish.git)
-101.  color-convert@1.9.3 (Qix-/color-convert)
-102.  text-hex@1.0.0 (https://github.com/3rd-Eden/text-hex)
-103.  kuler@2.0.0 (https://github.com/3rd-Eden/kuler)
-104.  enabled@2.0.0 (git://github.com/3rd-Eden/enabled.git)
-105.  is-stream@2.0.1 (sindresorhus/is-stream)
-106.  one-time@1.0.0 (https://github.com/3rd-Eden/one-time.git)
-107.  fn.name@1.1.0 (https://github.com/3rd-Eden/fn.name)
-108.  stack-trace@0.0.10 (git://github.com/felixge/node-stack-trace.git)
-109.  win-ca@3.5.1 (git+https://github.com/ukoloff/win-ca.git)
-110.  is-electron@2.2.2 (git@github.com:cheton/is-electron.git)
-111.  node-forge@1.3.3 (https://github.com/digitalbazaar/forge)
-112.  split@1.0.1 (git://github.com/dominictarr/split.git)
-113.  through@2.3.8 (https://github.com/dominictarr/through.git)
-114.  make-dir@1.3.0 (sindresorhus/make-dir)
-115.  pify@3.0.0 (sindresorhus/pify)
-116.  lossless-json@4.0.2 (https://github.com/josdejong/lossless-json.git)
-117.  reflect-metadata@0.2.2 (https://github.com/rbuckton/reflect-metadata.git)
-118.  @camunda8/orchestration-cluster-api@8.8.4 (git+https://github.com/camunda/orchestration-cluster-api-js.git)
-119.  zod@4.3.6 (git+https://github.com/colinhacks/zod.git)
-120.  typed-duration@1.0.13 (git+https://github.com/jwulf/typed-duration.git)
-121.  fast-xml-parser@5.5.6 (git+https://github.com/NaturalIntelligence/fast-xml-parser.git)
-122.  dayjs@1.11.5 (https://github.com/iamkun/dayjs.git)
-123.  chalk@2.4.2 (chalk/chalk)
-124.  escape-string-regexp@1.0.5 (sindresorhus/escape-string-regexp)
-125.  ansi-styles@3.2.1 (chalk/ansi-styles)
-126.  promise-retry@1.1.1 (git://github.com/IndigoUnited/node-promise-retry.git)
-127.  err-code@1.1.2 (git://github.com/IndigoUnited/js-err-code.git)
-128.  retry@0.10.1 (git://github.com/tim-kos/node-retry.git)
-129.  @grpc/grpc-js@1.12.5 (https://github.com/grpc/grpc-node/tree/master/packages/grpc-js)
-130.  @js-sdsl/ordered-map@4.4.2 (https://github.com/js-sdsl/js-sdsl.git)
-131.  @grpc/proto-loader@0.7.13 (https://github.com/grpc/grpc-node.git)
-132.  lodash.camelcase@4.3.0 (lodash/lodash)
-133.  protobufjs@7.2.5 (protobufjs/protobuf.js)
-134.  @protobufjs/aspromise@1.1.2 (https://github.com/dcodeIO/protobuf.js.git)
-135.  @protobufjs/base64@1.1.2 (https://github.com/dcodeIO/protobuf.js.git)
-136.  @protobufjs/eventemitter@1.1.0 (https://github.com/dcodeIO/protobuf.js.git)
-137.  @protobufjs/float@1.0.2 (https://github.com/dcodeIO/protobuf.js.git)
-138.  @protobufjs/inquire@1.1.0 (https://github.com/dcodeIO/protobuf.js.git)
-139.  @protobufjs/utf8@1.1.0 (https://github.com/dcodeIO/protobuf.js.git)
-140.  @protobufjs/pool@1.1.0 (https://github.com/dcodeIO/protobuf.js.git)
-141.  @protobufjs/codegen@2.0.4 (https://github.com/dcodeIO/protobuf.js.git)
-142.  @protobufjs/fetch@1.1.0 (https://github.com/dcodeIO/protobuf.js.git)
-143.  @protobufjs/path@1.1.2 (https://github.com/dcodeIO/protobuf.js.git)
-144.  long@5.2.4 (https://github.com/dcodeIO/long.js.git)
-145.  form-data@4.0.5 (git://github.com/form-data/form-data.git)
-146.  combined-stream@1.0.8 (git://github.com/felixge/node-combined-stream.git)
-147.  delayed-stream@1.0.0 (git://github.com/felixge/node-delayed-stream.git)
-148.  mime-types@2.1.35 (jshttp/mime-types)
-149.  mime-db@1.52.0 (jshttp/mime-db)
-150.  asynckit@0.4.0 (git+https://github.com/alexindigo/asynckit.git)
-151.  es-set-tostringtag@2.1.0 (git+https://github.com/es-shims/es-set-tostringtag.git)
-152.  get-intrinsic@1.3.0 (git+https://github.com/ljharb/get-intrinsic.git)
-153.  es-object-atoms@1.1.1 (git+https://github.com/ljharb/es-object-atoms.git)
-154.  es-errors@1.3.0 (git+https://github.com/ljharb/es-errors.git)
-155.  math-intrinsics@1.1.0 (git+https://github.com/es-shims/math-intrinsics.git)
-156.  gopd@1.2.0 (git+https://github.com/ljharb/gopd.git)
-157.  es-define-property@1.0.1 (git+https://github.com/ljharb/es-define-property.git)
-158.  has-symbols@1.1.0 (git://github.com/inspect-js/has-symbols.git)
-159.  get-proto@1.0.1 (git+https://github.com/ljharb/get-proto.git)
-160.  dunder-proto@1.0.1 (git+https://github.com/es-shims/dunder-proto.git)
-161.  call-bind-apply-helpers@1.0.2 (git+https://github.com/ljharb/call-bind-apply-helpers.git)
-162.  has-tostringtag@1.0.2 (git+https://github.com/inspect-js/has-tostringtag.git)
-163.  mri@1.2.0 (lukeed/mri)
-164.  min-dash@4.2.1 (git+https://github.com/bpmn-io/min-dash.git)
-165.  parents@1.0.1 (git://github.com/substack/node-parents.git)
-166.  path-platform@0.11.15 (http://github.com/tjfontaine/node-path-platform.git)
-167.  fast-glob@3.3.2 (mrmlnc/fast-glob)
-168.  glob-parent@5.1.2 (gulpjs/glob-parent)
-169.  is-glob@4.0.3 (micromatch/is-glob)
-170.  is-extglob@2.1.1 (jonschlinkert/is-extglob)
-171.  micromatch@4.0.8 (micromatch/micromatch)
-172.  braces@3.0.3 (micromatch/braces)
-173.  fill-range@7.1.1 (jonschlinkert/fill-range)
-174.  to-regex-range@5.0.1 (micromatch/to-regex-range)
-175.  is-number@7.0.0 (jonschlinkert/is-number)
-176.  picomatch@2.3.1 (micromatch/picomatch)
-177.  merge2@1.4.1 (git@github.com:teambition/merge2.git)
-178.  @nodelib/fs.walk@1.2.8 (https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk)
-179.  @nodelib/fs.scandir@2.1.5 (https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.scandir)
-180.  @nodelib/fs.stat@2.0.5 (https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat)
-181.  run-parallel@1.2.0 (git://github.com/feross/run-parallel.git)
-182.  queue-microtask@1.2.3 (git://github.com/feross/queue-microtask.git)
-183.  fastq@1.13.0 (git+https://github.com/mcollina/fastq.git)
-184.  reusify@1.0.4 (git+https://github.com/mcollina/reusify.git)
-185.  @sentry/integrations@7.114.0 (git://github.com/getsentry/sentry-javascript.git)
-186.  @sentry/utils@7.114.0 (git://github.com/getsentry/sentry-javascript.git)
-187.  localforage@1.10.0 (git://github.com/localForage/localForage.git)
-188.  epipebomb@1.0.0 (git://github.com/mhart/epipebomb.git)
-189.  style-loader@4.0.0 (webpack-contrib/style-loader)
-190.  css-loader@7.1.2 (webpack-contrib/css-loader)
-191.  @camunda/form-playground@0.20.0 (git+https://github.com/camunda/form-playground.git)
-192.  camunda-bpmn-js@5.6.1 (https://github.com/camunda/camunda-bpmn-js)
-193.  @ibm/plex@6.4.1 (https://github.com/ibm/plex.git)
-194.  camunda-dmn-js@3.1.1 (https://github.com/camunda/camunda-dmn-js)
-195.  @camunda/linting@3.40.1 (https://github.com/camunda/linting)
-196.  min-dash@4.2.2 (git+https://github.com/bpmn-io/min-dash.git)
-197.  react@16.14.0 (git+https://github.com/facebook/react.git)
-198.  object-assign@4.1.1 (sindresorhus/object-assign)
-199.  classnames@2.5.1 (git+https://github.com/JedWatson/classnames.git)
-200.  react-dom@16.14.0 (git+https://github.com/facebook/react.git)
-201.  scheduler@0.19.1 (https://github.com/facebook/react.git)
-202.  formik@2.0.4 (jaredpalmer/formik)
-203.  react-fast-compare@2.0.4 (git+https://github.com/FormidableLabs/react-fast-compare.git)
-204.  deepmerge@2.2.1 (git://github.com/KyleAMathews/deepmerge.git)
-205.  lodash-es@4.17.21 (lodash/lodash)
-206.  tiny-warning@1.0.3 (https://github.com/alexreardon/tiny-warning.git)
-207.  hoist-non-react-statics@3.3.2 (git://github.com/mridgway/hoist-non-react-statics.git)
-208.  react-is@16.13.1 (https://github.com/facebook/react.git)
-209.  drag-tabs@2.3.1 (git+ssh://git@github.com/bpmn-io/drag-tabs.git)
-210.  min-dom@4.1.0 (https://github.com/bpmn-io/min-dom)
-211.  mitt@3.0.1 (developit/mitt)
-212.  @bpmn-io/properties-panel@3.26.2 (git+https://github.com/bpmn-io/properties-panel.git)
-213.  preact-hooks@0.1.0
-214.  preact@10.19.3 (preactjs/preact)
-215.  preact-compat@4.0.0
-216.  jsx-runtime@1.0.0
-217.  feelers@1.4.0
-218.  @lezer/lr@1.4.2 (https://github.com/lezer-parser/lr.git)
-219.  @lezer/common@1.2.3 (https://github.com/lezer-parser/common.git)
-220.  @lezer/highlight@1.2.1 (https://github.com/lezer-parser/highlight.git)
-221.  feelin@3.2.0 (https://github.com/nikku/feelin)
-222.  luxon@3.5.0 (https://github.com/moment/luxon)
-223.  lezer-feel@1.8.1 (https://github.com/nikku/lezer-feel.git)
-224.  @codemirror/autocomplete@6.18.4 (https://github.com/codemirror/autocomplete.git)
-225.  @codemirror/state@6.5.1 (https://github.com/codemirror/state.git)
-226.  @marijn/find-cluster-break@1.0.2 (git+https://github.com/marijnh/find-cluster-break.git)
-227.  @codemirror/view@6.36.2 (https://github.com/codemirror/view.git)
-228.  style-mod@4.1.0 (git+https://github.com/marijnh/style-mod.git)
-229.  w3c-keyname@2.2.6 (git+https://github.com/marijnh/w3c-keyname.git)
-230.  @codemirror/language@6.10.8 (https://github.com/codemirror/language.git)
-231.  @codemirror/commands@6.8.0 (https://github.com/codemirror/commands.git)
-232.  @codemirror/lint@6.8.4 (https://github.com/codemirror/lint.git)
-233.  crelt@1.0.5 (git+https://github.com/marijnh/crelt.git)
-234.  @lezer/markdown@1.3.0 (https://github.com/lezer-parser/markdown.git)
-235.  @bpmn-io/feel-lint@1.4.0 (git+https://github.com/bpmn-io/feel-lint.git)
-236.  @bpmn-io/cm-theme@0.1.0-alpha.2
-237.  @bpmn-io/feel-editor@1.10.0 (git+https://github.com/bpmn-io/feel-editor.git)
-238.  lang-feel@2.3.0 (https://github.com/nikku/lang-feel.git)
-239.  focus-trap@7.5.2 (git+https://github.com/focus-trap/focus-trap.git)
-240.  tabbable@6.2.0 (git+https://github.com/focus-trap/tabbable.git)
-241.  bpmn-js-properties-panel@5.32.1 (https://github.com/bpmn-io/bpmn-js-properties-panel)
-242.  bpmn-js@18.3.1 (https://github.com/bpmn-io/bpmn-js)
-243.  diagram-js@15.2.4 (https://github.com/bpmn-io/diagram-js)
-244.  ids@1.0.5 (https://github.com/bpmn-io/ids)
-245.  @bpmn-io/extract-process-variables@1.0.1 (git+https://github.com/bpmn-io/extract-process-variables.git)
-246.  array-move@4.0.0 (sindresorhus/array-move)
-247.  dmn-js-properties-panel@3.7.0 (https://github.com/bpmn-io/dmn-js-properties-panel)
-248.  debug@4.3.7 (git://github.com/debug-js/debug.git)
-249.  ms@2.1.3 (vercel/ms)
-250.  events@3.3.0 (git://github.com/Gozala/events.git)
-251.  bpmn-moddle@9.0.1 (https://github.com/bpmn-io/bpmn-moddle)
-252.  moddle@7.0.0 (https://github.com/bpmn-io/moddle)
-253.  moddle-xml@11.0.0 (https://github.com/bpmn-io/moddle-xml)
-254.  saxen@10.0.0 (https://github.com/nikku/saxen)
-255.  dmn-moddle@10.0.0 (https://github.com/bpmn-io/dmn-moddle)
-256.  camunda-bpmn-moddle@7.0.1 (https://github.com/camunda/camunda-bpmn-moddle)
-257.  camunda-dmn-moddle@1.3.0 (https://github.com/camunda/camunda-dmn-moddle)
-258.  zeebe-bpmn-moddle@1.9.0 (https://github.com/camunda/zeebe-bpmn-moddle)
-259.  @sentry/browser@9.0.0 (git://github.com/getsentry/sentry-javascript.git)
-260.  @sentry/core@9.0.0 (git://github.com/getsentry/sentry-javascript.git)
-261.  @sentry-internal/browser-utils@9.0.0 (git://github.com/getsentry/sentry-javascript.git)
-262.  @sentry-internal/replay@9.0.0 (git+https://github.com/getsentry/sentry-javascript.git)
-263.  @sentry-internal/replay-canvas@9.0.0 (git+https://github.com/getsentry/sentry-javascript.git)
-264.  @sentry-internal/feedback@9.0.0 (git://github.com/getsentry/sentry-javascript.git)
-265.  @sentry/integrations@7.114.0 (git://github.com/getsentry/sentry-javascript.git)
-266.  @sentry/utils@7.114.0 (git://github.com/getsentry/sentry-javascript.git)
-267.  ua-parser-js@1.0.39 (https://github.com/faisalman/ua-parser-js.git)
-268.  inherits-browser@0.1.0 (git+https://github.com/nikku/inherits-browser.git)
-269.  object-refs@0.4.0 (https://github.com/bpmn-io/object-refs)
-270.  mixpanel-browser@2.55.1 (https://github.com/mixpanel/mixpanel-js.git)
-271.  p-defer@4.0.1 (sindresorhus/p-defer)
-272.  p-series@3.0.0 (sindresorhus/p-series)
-273.  sourcemapped-stacktrace@1.1.11 (http://github.com/novocaine/sourcemapped-stacktrace)
-274.  @bpmn-io/replace-ids@0.2.0 (git+https://github.com/bpmn-io/replace-ids.git)
-275.  bpmnlint@11.6.0 (https://github.com/bpmn-io/bpmnlint)
-276.  bpmnlint-plugin-camunda-compat@2.39.2 (https://github.com/camunda/bpmnlint-plugin-camunda-compat)
-277.  bpmnlint-utils@1.1.1 (https://github.com/bpmn-io/bpmnlint-utils)
-278.  @bpmn-io/moddle-utils@0.2.1 (https://github.com/bpmn-io/moddle-utils)
-279.  semver-compare@1.0.0 (git://github.com/substack/semver-compare.git)
-280.  modeler-moddle@0.2.0 (https://github.com/camunda/modeler-moddle)
-281.  htm@3.1.1 (developit/htm)
-282.  htm_preact@undefined
-283.  @codemirror/search@6.5.6 (https://github.com/codemirror/search.git)
-284.  codemirror@6.0.1 (https://github.com/codemirror/basic-setup.git)
-285.  didi@10.2.2 (git://github.com/nikku/didi.git)
-286.  fast-xml-builder@1.1.4 (git+https://github.com/NaturalIntelligence/fast-xml-builder.git)
-287.  fast-xml-parser@5.5.6 (git+https://github.com/NaturalIntelligence/fast-xml-parser.git)
-288.  path-expression-matcher@1.1.3 (https://github.com/NaturalIntelligence/path-expression-matcher)
-289.  strnum@2.2.0 (https://github.com/NaturalIntelligence/strnum)
-290.  @bpmn-io/add-exporter@0.2.0 (git+ssh://git@github.com/bpmn-io/add-exporter.git)
-291.  @bpmn-io/variable-resolver@1.3.3
-292.  domify@2.0.0 (sindresorhus/domify)
-293.  bpmn-js-color-picker@0.7.1 (https://github.com/bpmn-io/bpmn-js-color-picker.git)
-294.  bpmn-js-create-append-anything@0.6.0 (git+https://github.com/bpmn-io/bpmn-js-create-append-anything.git)
-295.  bpmn-js-element-templates@2.5.3 (https://github.com/bpmn-io/bpmn-js-element-templates)
-296.  semver@7.6.3 (git+https://github.com/npm/node-semver.git)
-297.  bpmn-js-executable-fix@0.2.1 (git+https://github.com/bpmn-io/bpmn-js-executable-fix.git)
-298.  bpmn-js-tracking@0.6.0 (git+https://github.com/bpmn-io/bpmn-js-tracking.git)
-299.  diagram-js-direct-editing@3.2.0 (https://github.com/bpmn-io/diagram-js-direct-editing)
-300.  tiny-svg@3.1.2 (https://github.com/bpmn-io/tiny-svg)
-301.  camunda-bpmn-js-behaviors@1.9.1 (https://github.com/camunda/camunda-bpmn-js-behaviors)
-302.  diagram-js-minimap@5.2.0 (git@github.com:bpmn-io/diagram-js-minimap.git)
-303.  @bpmn-io/align-to-origin@0.7.0 (git+ssh://git@github.com/bpmn-io/align-to-origin.git)
-304.  @camunda/improved-canvas@1.7.6 (git+https://github.com/camunda/improved-canvas.git)
-305.  rgbcolor@1.0.1 (https://github.com/yetzt/node-rgbcolor.git)
-306.  diagram-js-grid@1.1.0 (git@github.com:bpmn-io/diagram-js-grid.git)
-307.  diagram-js-origin@1.4.0 (https://github.com/bpmn-io/diagram-js-origin)
-308.  performance-now@2.1.0 (git://github.com/braveg1rl/performance-now.git)
-309.  raf@3.4.1 (git://github.com/chrisdickinson/raf.git)
-310.  stackblur-canvas@2.5.0 (https://github.com/flozz/StackBlur.git)
-311.  @bpmn-io/dmn-migrate@0.5.0 (git+https://github.com/bpmn-io/dmn-migrate.git)
-312.  @bpmn-io/dmn-variable-resolver@0.7.0
-313.  @camunda/execution-platform@0.3.2 (git+ssh://git@github.com/camunda/execution-platform.git)
-314.  css.escape@1.5.1 (https://github.com/mathiasbynens/CSS.escape.git)
-315.  dmn-js-boxed-expression@17.1.0 (https://github.com/bpmn-io/dmn-js)
-316.  dmn-js-decision-table@17.1.0 (https://github.com/bpmn-io/dmn-js)
-317.  dmn-js-drd@17.1.0 (https://github.com/bpmn-io/dmn-js)
-318.  dmn-js-literal-expression@17.1.0 (https://github.com/bpmn-io/dmn-js)
-319.  dmn-js-shared@17.1.0 (https://github.com/bpmn-io/dmn-js)
-320.  dmn-js@17.1.0 (https://github.com/bpmn-io/dmn-js)
-321.  escape-html@1.0.3 (component/escape-html)
-322.  inferno@5.6.3 (https://github.com/infernojs/inferno)
-323.  selection-ranges@3.0.3 (git+ssh://git@github.com/nikku/selection-ranges.git)
-324.  selection-update@0.1.2 (git+ssh://git@github.com/nikku/selection-update.git)
-325.  table-js@9.2.0 (https://github.com/bpmn-io/table-js)
-326.  @bpmn-io/form-js-editor@1.14.0 (git+https://github.com/bpmn-io/form-js.git)
-327.  @bpmn-io/form-js-playground@1.14.0 (git+https://github.com/bpmn-io/form-js.git)
-328.  @bpmn-io/form-js-viewer@1.14.0 (git+https://github.com/bpmn-io/form-js.git)
-329.  downloadjs@1.4.7 (https://github.com/rndme/download.git)
-330.  file-drops@0.5.0 (git+ssh://git@github.com/nikku/file-drops.git)
-331.  flatpickr@4.6.13 (git+https://github.com/chmln/flatpickr.git)
-332.  lodash@4.17.21 (lodash/lodash)
-333.  @codemirror/lang-xml@6.1.0 (https://github.com/codemirror/lang-xml.git)
-334.  @lezer/xml@1.0.1 (https://github.com/lezer-parser/xml.git)
-335.  canvg@4.0.3 (https://github.com/canvg/canvg)
-336.  clsx@2.1.0 (lukeed/clsx)
-337.  path-intersection@3.0.0 (https://github.com/bpmn-io/path-intersection)
-338.  svg-pathdata@6.0.3 (https://github.com/nfroidure/svg-pathdata.git)
-339.  zeebe-dmn-moddle@1.0.0 (https://github.com/camunda/zeebe-dmn-moddle)
-340.  @bpmn-io/element-templates-validator@2.3.3 (git+https://github.com/bpmn-io/element-templates-validator.git)
-341.  uuid@11.0.3 (https://github.com/uuidjs/uuid.git)
-342.  @bpmn-io/draggle@4.1.1 (https://github.com/bpmn-io/draggle.git)
-343.  big.js@6.2.2 (https://github.com/MikeMcl/big.js.git)
-344.  @codemirror/lang-json@6.0.1 (https://github.com/codemirror/lang-json.git)
-345.  @lezer/json@1.0.0 (https://github.com/lezer-parser/json.git)
-346.  dompurify@3.2.4 (git://github.com/cure53/DOMPurify.git)
-347.  marked@15.0.7 (git://github.com/markedjs/marked.git)
-348.  vscode-windows-ca-certs@0.3.0 (git+https://github.com/Microsoft/vscode-windows-ca-certs.git)
+10.   require-in-the-middle@7.5.2 (git+https://github.com/nodejs/require-in-the-middle.git)
+11.   debug@4.4.3 (git://github.com/debug-js/debug.git)
+12.   ms@2.1.3 (vercel/ms)
+13.   supports-color@7.2.0 (chalk/supports-color)
+14.   has-flag@4.0.0 (sindresorhus/has-flag)
+15.   module-details-from-path@1.0.4 (git+https://github.com/watson/module-details-from-path.git)
+16.   resolve@1.22.12 (ssh://github.com/browserify/resolve.git)
+17.   es-errors@1.3.0 (git+https://github.com/ljharb/es-errors.git)
+18.   path-parse@1.0.7 (https://github.com/jbgutierrez/path-parse.git)
+19.   is-core-module@2.16.1 (git+https://github.com/inspect-js/is-core-module.git)
+20.   hasown@2.0.2 (git+https://github.com/inspect-js/hasOwn.git)
+21.   function-bind@1.1.2 (https://github.com/Raynos/function-bind.git)
+22.   import-in-the-middle@1.15.0 (git+ssh://git@github.com/nodejs/import-in-the-middle.git)
+23.   forwarded-parse@2.1.2 (lpinca/forwarded-parse)
+24.   @sentry/core@9.47.1 (git://github.com/getsentry/sentry-javascript.git)
+25.   @sentry/node-core@9.47.1 (git://github.com/getsentry/sentry-javascript.git)
+26.   @sentry/opentelemetry@9.47.1 (git://github.com/getsentry/sentry-javascript.git)
+27.   @opentelemetry/sdk-trace-base@1.30.1 (open-telemetry/opentelemetry-js)
+28.   @opentelemetry/resources@1.30.1 (open-telemetry/opentelemetry-js)
+29.   @opentelemetry/context-async-hooks@1.30.1 (open-telemetry/opentelemetry-js)
+30.   @opentelemetry/instrumentation-undici@0.10.1 (open-telemetry/opentelemetry-js-contrib)
+31.   @opentelemetry/instrumentation-fs@0.19.1 (open-telemetry/opentelemetry-js-contrib)
+32.   @opentelemetry/instrumentation-express@0.47.1 (open-telemetry/opentelemetry-js-contrib)
+33.   minimatch@9.0.9 (git://github.com/isaacs/minimatch.git)
+34.   brace-expansion@2.1.0 (git://github.com/juliangruber/brace-expansion.git)
+35.   balanced-match@1.0.2 (git://github.com/juliangruber/balanced-match.git)
+36.   @opentelemetry/instrumentation-graphql@0.47.1 (open-telemetry/opentelemetry-js-contrib)
+37.   @opentelemetry/instrumentation-kafkajs@0.7.1 (open-telemetry/opentelemetry-js-contrib)
+38.   @opentelemetry/instrumentation-lru-memoizer@0.44.1 (open-telemetry/opentelemetry-js-contrib)
+39.   @opentelemetry/instrumentation-mongodb@0.52.0 (open-telemetry/opentelemetry-js-contrib)
+40.   @opentelemetry/instrumentation-mongoose@0.46.1 (open-telemetry/opentelemetry-js-contrib)
+41.   @opentelemetry/instrumentation-mysql@0.45.1 (open-telemetry/opentelemetry-js-contrib)
+42.   @opentelemetry/instrumentation-mysql2@0.45.2 (open-telemetry/opentelemetry-js-contrib)
+43.   @opentelemetry/sql-common@0.40.1 (open-telemetry/opentelemetry-js-contrib)
+44.   @opentelemetry/instrumentation-ioredis@0.47.1 (open-telemetry/opentelemetry-js-contrib)
+45.   @opentelemetry/redis-common@0.36.2 (open-telemetry/opentelemetry-js-contrib)
+46.   @opentelemetry/instrumentation-redis-4@0.46.1 (open-telemetry/opentelemetry-js-contrib)
+47.   @opentelemetry/instrumentation-pg@0.51.1 (open-telemetry/opentelemetry-js-contrib)
+48.   @prisma/instrumentation@6.11.1 (https://github.com/prisma/prisma.git)
+49.   @opentelemetry/instrumentation-hapi@0.45.2 (open-telemetry/opentelemetry-js-contrib)
+50.   @opentelemetry/instrumentation-koa@0.47.1 (open-telemetry/opentelemetry-js-contrib)
+51.   @opentelemetry/instrumentation-connect@0.43.1 (open-telemetry/opentelemetry-js-contrib)
+52.   @opentelemetry/instrumentation-knex@0.44.1 (open-telemetry/opentelemetry-js-contrib)
+53.   @opentelemetry/instrumentation-tedious@0.18.1 (open-telemetry/opentelemetry-js-contrib)
+54.   @opentelemetry/instrumentation-generic-pool@0.43.1 (open-telemetry/opentelemetry-js-contrib)
+55.   @opentelemetry/instrumentation-dataloader@0.16.1 (open-telemetry/opentelemetry-js-contrib)
+56.   @opentelemetry/instrumentation-amqplib@0.46.1 (open-telemetry/opentelemetry-js-contrib)
+57.   @camunda8/sdk@8.8.9 (git+https://github.com/camunda/camunda-8-js-sdk.git)
+58.   got@11.8.6 (sindresorhus/got)
+59.   @sindresorhus/is@4.6.0 (sindresorhus/is)
+60.   p-cancelable@2.1.1 (sindresorhus/p-cancelable)
+61.   @szmarczak/http-timer@4.0.6 (git+https://github.com/szmarczak/http-timer.git)
+62.   defer-to-connect@2.0.1 (git+https://github.com/szmarczak/defer-to-connect.git)
+63.   cacheable-lookup@5.0.4 (git+https://github.com/szmarczak/cacheable-lookup.git)
+64.   cacheable-request@7.0.4 (lukechilds/cacheable-request)
+65.   normalize-url@6.1.0 (sindresorhus/normalize-url)
+66.   get-stream@5.2.0 (sindresorhus/get-stream)
+67.   pump@3.0.4 (git://github.com/mafintosh/pump.git)
+68.   once@1.4.0 (git://github.com/isaacs/once)
+69.   wrappy@1.0.2 (https://github.com/npm/wrappy)
+70.   end-of-stream@1.4.5 (git://github.com/mafintosh/end-of-stream.git)
+71.   http-cache-semantics@4.2.0 (git+https://github.com/kornelski/http-cache-semantics.git)
+72.   responselike@2.0.1 (https://github.com/sindresorhus/responselike.git)
+73.   lowercase-keys@2.0.0 (sindresorhus/lowercase-keys)
+74.   clone-response@1.0.3 (git+https://github.com/sindresorhus/clone-response.git)
+75.   mimic-response@1.0.1 (sindresorhus/mimic-response)
+76.   keyv@4.5.4 (git+https://github.com/jaredwray/keyv.git)
+77.   json-buffer@3.0.1 (git://github.com/dominictarr/json-buffer.git)
+78.   decompress-response@6.0.0 (sindresorhus/decompress-response)
+79.   http2-wrapper@1.0.3 (git+https://github.com/szmarczak/http2-wrapper.git)
+80.   quick-lru@5.1.1 (sindresorhus/quick-lru)
+81.   resolve-alpn@1.2.1 (git+https://github.com/szmarczak/resolve-alpn.git)
+82.   lodash.mergewith@4.6.2 (lodash/lodash)
+83.   typed-env@2.0.0 (git+https://github.com/itslukej/typed-env.git)
+84.   jwt-decode@4.0.0 (git://github.com/auth0/jwt-decode)
+85.   winston@3.19.0 (https://github.com/winstonjs/winston.git)
+86.   logform@2.7.0 (git+https://github.com/winstonjs/logform.git)
+87.   @colors/colors@1.6.0 (http://github.com/DABH/colors.js.git)
+88.   triple-beam@1.4.1 (git+https://github.com/winstonjs/triple-beam.git)
+89.   safe-stable-stringify@2.5.0 (git+https://github.com/BridgeAR/safe-stable-stringify.git)
+90.   fecha@4.2.3 (https://taylorhakes@github.com/taylorhakes/fecha.git)
+91.   winston-transport@4.9.0 (git@github.com:winstonjs/winston-transport.git)
+92.   readable-stream@3.6.2 (git://github.com/nodejs/readable-stream)
+93.   util-deprecate@1.0.2 (git://github.com/TooTallNate/util-deprecate.git)
+94.   inherits@2.0.4 (git://github.com/isaacs/inherits)
+95.   string_decoder@1.3.0 (git://github.com/nodejs/string_decoder.git)
+96.   safe-buffer@5.2.1 (git://github.com/feross/safe-buffer.git)
+97.   async@3.2.6 (https://github.com/caolan/async.git)
+98.   @dabh/diagnostics@2.0.8 (git://github.com/DABH/diagnostics.git)
+99.   @so-ric/colorspace@1.1.6 (https://github.com/so-ric/colorspace)
+100.  kuler@2.0.0 (https://github.com/3rd-Eden/kuler)
+101.  enabled@2.0.0 (git://github.com/3rd-Eden/enabled.git)
+102.  is-stream@2.0.1 (sindresorhus/is-stream)
+103.  one-time@1.0.0 (https://github.com/3rd-Eden/one-time.git)
+104.  fn.name@1.1.0 (https://github.com/3rd-Eden/fn.name)
+105.  stack-trace@0.0.10 (git://github.com/felixge/node-stack-trace.git)
+106.  win-ca@3.5.1 (git+https://github.com/ukoloff/win-ca.git)
+107.  is-electron@2.2.2 (git@github.com:cheton/is-electron.git)
+108.  node-forge@1.4.0 (https://github.com/digitalbazaar/forge)
+109.  split@1.0.1 (git://github.com/dominictarr/split.git)
+110.  through@2.3.8 (https://github.com/dominictarr/through.git)
+111.  make-dir@1.3.0 (sindresorhus/make-dir)
+112.  pify@3.0.0 (sindresorhus/pify)
+113.  lossless-json@4.3.0 (https://github.com/josdejong/lossless-json.git)
+114.  reflect-metadata@0.2.2 (https://github.com/rbuckton/reflect-metadata.git)
+115.  @camunda8/orchestration-cluster-api@8.8.4 (git+https://github.com/camunda/orchestration-cluster-api-js.git)
+116.  zod@4.3.6 (git+https://github.com/colinhacks/zod.git)
+117.  typed-duration@1.0.13 (git+https://github.com/jwulf/typed-duration.git)
+118.  fast-xml-parser@5.5.11 (git+https://github.com/NaturalIntelligence/fast-xml-parser.git)
+119.  dayjs@1.11.20 (https://github.com/iamkun/dayjs.git)
+120.  chalk@2.4.2 (chalk/chalk)
+121.  escape-string-regexp@1.0.5 (sindresorhus/escape-string-regexp)
+122.  ansi-styles@3.2.1 (chalk/ansi-styles)
+123.  color-convert@1.9.3 (Qix-/color-convert)
+124.  color-name@1.1.3 (git@github.com:dfcreative/color-name.git)
+125.  promise-retry@1.1.1 (git://github.com/IndigoUnited/node-promise-retry.git)
+126.  err-code@1.1.2 (git://github.com/IndigoUnited/js-err-code.git)
+127.  retry@0.10.1 (git://github.com/tim-kos/node-retry.git)
+128.  @grpc/grpc-js@1.14.3 (https://github.com/grpc/grpc-node/tree/master/packages/grpc-js)
+129.  @js-sdsl/ordered-map@4.4.2 (https://github.com/js-sdsl/js-sdsl.git)
+130.  @grpc/proto-loader@0.8.0 (https://github.com/grpc/grpc-node.git)
+131.  lodash.camelcase@4.3.0 (lodash/lodash)
+132.  protobufjs@7.6.4 (protobufjs/protobuf.js)
+133.  @protobufjs/aspromise@1.1.2 (https://github.com/dcodeIO/protobuf.js.git)
+134.  @protobufjs/base64@1.1.2 (https://github.com/dcodeIO/protobuf.js.git)
+135.  @protobufjs/eventemitter@1.1.1 (https://github.com/dcodeIO/protobuf.js.git)
+136.  @protobufjs/float@1.0.2 (https://github.com/dcodeIO/protobuf.js.git)
+137.  @protobufjs/utf8@1.1.1 (https://github.com/dcodeIO/protobuf.js.git)
+138.  @protobufjs/pool@1.1.0 (https://github.com/dcodeIO/protobuf.js.git)
+139.  long@5.3.2 (https://github.com/dcodeIO/long.js.git)
+140.  @protobufjs/codegen@2.0.5 (https://github.com/dcodeIO/protobuf.js.git)
+141.  @protobufjs/fetch@1.1.1 (https://github.com/dcodeIO/protobuf.js.git)
+142.  @protobufjs/path@1.1.2 (https://github.com/dcodeIO/protobuf.js.git)
+143.  form-data@4.0.5 (git://github.com/form-data/form-data.git)
+144.  combined-stream@1.0.8 (git://github.com/felixge/node-combined-stream.git)
+145.  delayed-stream@1.0.0 (git://github.com/felixge/node-delayed-stream.git)
+146.  mime-types@2.1.35 (jshttp/mime-types)
+147.  mime-db@1.52.0 (jshttp/mime-db)
+148.  asynckit@0.4.0 (git+https://github.com/alexindigo/asynckit.git)
+149.  es-set-tostringtag@2.1.0 (git+https://github.com/es-shims/es-set-tostringtag.git)
+150.  get-intrinsic@1.3.0 (git+https://github.com/ljharb/get-intrinsic.git)
+151.  es-object-atoms@1.1.1 (git+https://github.com/ljharb/es-object-atoms.git)
+152.  math-intrinsics@1.1.0 (git+https://github.com/es-shims/math-intrinsics.git)
+153.  gopd@1.2.0 (git+https://github.com/ljharb/gopd.git)
+154.  es-define-property@1.0.1 (git+https://github.com/ljharb/es-define-property.git)
+155.  has-symbols@1.1.0 (git://github.com/inspect-js/has-symbols.git)
+156.  get-proto@1.0.1 (git+https://github.com/ljharb/get-proto.git)
+157.  dunder-proto@1.0.1 (git+https://github.com/es-shims/dunder-proto.git)
+158.  call-bind-apply-helpers@1.0.2 (git+https://github.com/ljharb/call-bind-apply-helpers.git)
+159.  has-tostringtag@1.0.2 (git+https://github.com/inspect-js/has-tostringtag.git)
+160.  mri@1.2.0 (lukeed/mri)
+161.  min-dash@4.2.3 (git+https://github.com/bpmn-io/min-dash.git)
+162.  parents@1.0.1 (git://github.com/substack/node-parents.git)
+163.  path-platform@0.11.15 (http://github.com/tjfontaine/node-path-platform.git)
+164.  fast-glob@3.3.3 (mrmlnc/fast-glob)
+165.  glob-parent@5.1.2 (gulpjs/glob-parent)
+166.  is-glob@4.0.3 (micromatch/is-glob)
+167.  is-extglob@2.1.1 (jonschlinkert/is-extglob)
+168.  micromatch@4.0.8 (micromatch/micromatch)
+169.  braces@3.0.3 (micromatch/braces)
+170.  fill-range@7.1.1 (jonschlinkert/fill-range)
+171.  to-regex-range@5.0.1 (micromatch/to-regex-range)
+172.  is-number@7.0.0 (jonschlinkert/is-number)
+173.  picomatch@2.3.2 (micromatch/picomatch)
+174.  merge2@1.4.1 (git@github.com:teambition/merge2.git)
+175.  @nodelib/fs.walk@1.2.8 (https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk)
+176.  @nodelib/fs.scandir@2.1.5 (https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.scandir)
+177.  @nodelib/fs.stat@2.0.5 (https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat)
+178.  run-parallel@1.2.0 (git://github.com/feross/run-parallel.git)
+179.  queue-microtask@1.2.3 (git://github.com/feross/queue-microtask.git)
+180.  fastq@1.20.1 (git+https://github.com/mcollina/fastq.git)
+181.  reusify@1.1.0 (git+https://github.com/mcollina/reusify.git)
+182.  @sentry/integrations@7.114.0 (git://github.com/getsentry/sentry-javascript.git)
+183.  @sentry/utils@7.114.0 (git://github.com/getsentry/sentry-javascript.git)
+184.  localforage@1.10.0 (git://github.com/localForage/localForage.git)
+185.  epipebomb@1.0.0 (git://github.com/mhart/epipebomb.git)
+186.  style-loader@4.0.0 (webpack-contrib/style-loader)
+187.  css-loader@7.1.4 (webpack/css-loader)
+188.  @camunda/form-playground@0.20.0 (git+https://github.com/camunda/form-playground.git)
+189.  camunda-bpmn-js@5.26.0 (https://github.com/camunda/camunda-bpmn-js)
+190.  @ibm/plex@6.4.1 (https://github.com/ibm/plex.git)
+191.  camunda-dmn-js@3.7.0 (https://github.com/camunda/camunda-dmn-js)
+192.  @camunda/linting@3.48.1 (https://github.com/camunda/linting)
+193.  min-dash@4.2.3 (git+https://github.com/bpmn-io/min-dash.git)
+194.  react@18.3.1 (https://github.com/facebook/react.git)
+195.  classnames@2.5.1 (git+https://github.com/JedWatson/classnames.git)
+196.  react-dom@18.3.1 (https://github.com/facebook/react.git)
+197.  scheduler@0.23.2 (https://github.com/facebook/react.git)
+198.  formik@2.4.9 (jaredpalmer/formik)
+199.  deepmerge@2.2.1 (git://github.com/KyleAMathews/deepmerge.git)
+200.  lodash-es@4.18.1 (lodash/lodash)
+201.  react-fast-compare@2.0.4 (git+https://github.com/FormidableLabs/react-fast-compare.git)
+202.  tiny-warning@1.0.3 (https://github.com/alexreardon/tiny-warning.git)
+203.  hoist-non-react-statics@3.3.2 (git://github.com/mridgway/hoist-non-react-statics.git)
+204.  react-is@16.13.1 (https://github.com/facebook/react.git)
+205.  drag-tabs@2.3.1 (git+ssh://git@github.com/bpmn-io/drag-tabs.git)
+206.  min-dom@4.2.1 (https://github.com/bpmn-io/min-dom)
+207.  mitt@3.0.1 (developit/mitt)
+208.  @bpmn-io/properties-panel@3.40.6 (git+https://github.com/bpmn-io/properties-panel.git)
+209.  preact-hooks@0.1.0
+210.  preact@10.19.3 (preactjs/preact)
+211.  preact-compat@4.0.0
+212.  jsx-runtime@1.0.0
+213.  domify@3.0.0 (sindresorhus/domify)
+214.  feelers@1.5.1
+215.  @lezer/lr@1.4.8 (https://github.com/lezer-parser/lr.git)
+216.  @lezer/common@1.5.2 (https://github.com/lezer-parser/common.git)
+217.  @lezer/highlight@1.2.3 (https://github.com/lezer-parser/highlight.git)
+218.  @bpmn-io/feelin@6.1.0 (https://github.com/bpmn-io/feelin)
+219.  luxon@3.7.2 (https://github.com/moment/luxon)
+220.  @bpmn-io/lezer-feel@2.3.1 (https://github.com/bpmn-io/lezer-feel.git)
+221.  @codemirror/autocomplete@6.20.1 (git+https://github.com/codemirror/autocomplete.git)
+222.  @codemirror/state@6.6.0 (git+https://github.com/codemirror/state.git)
+223.  @marijn/find-cluster-break@1.0.2 (git+https://github.com/marijnh/find-cluster-break.git)
+224.  @codemirror/view@6.41.0 (git+https://github.com/codemirror/view.git)
+225.  style-mod@4.1.3 (git+https://github.com/marijnh/style-mod.git)
+226.  w3c-keyname@2.2.8 (git+https://github.com/marijnh/w3c-keyname.git)
+227.  crelt@1.0.6 (git+https://github.com/marijnh/crelt.git)
+228.  @codemirror/language@6.12.3 (git+https://github.com/codemirror/language.git)
+229.  @codemirror/commands@6.10.3 (git+https://github.com/codemirror/commands.git)
+230.  @codemirror/lint@6.9.5 (git+https://github.com/codemirror/lint.git)
+231.  @lezer/markdown@1.6.3 (https://github.com/lezer-parser/markdown.git)
+232.  @bpmn-io/feel-lint@3.1.0 (git+https://github.com/bpmn-io/feel-lint.git)
+233.  @bpmn-io/cm-theme@0.1.0-alpha.2
+234.  @bpmn-io/feel-editor@2.5.2 (git+https://github.com/bpmn-io/feel-editor.git)
+235.  @bpmn-io/lang-feel@3.0.0 (https://github.com/bpmn-io/lang-feel.git)
+236.  @camunda/feel-builtins@1.1.0 (git+https://github.com/camunda/feel-builtins.git)
+237.  focus-trap@8.0.1 (git+https://github.com/focus-trap/focus-trap.git)
+238.  tabbable@6.4.0 (git+https://github.com/focus-trap/tabbable.git)
+239.  bpmn-js-properties-panel@5.53.0 (https://github.com/bpmn-io/bpmn-js-properties-panel)
+240.  bpmn-js@18.14.0 (https://github.com/bpmn-io/bpmn-js)
+241.  diagram-js@15.11.0 (https://github.com/bpmn-io/diagram-js)
+242.  ids@3.0.2 (https://github.com/bpmn-io/ids)
+243.  @bpmn-io/extract-process-variables@2.2.1 (git+https://github.com/bpmn-io/extract-process-variables.git)
+244.  array-move@4.0.0 (sindresorhus/array-move)
+245.  dmn-js-properties-panel@3.11.0 (https://github.com/bpmn-io/dmn-js-properties-panel)
+246.  debug@4.4.3 (git://github.com/debug-js/debug.git)
+247.  ms@2.1.3 (vercel/ms)
+248.  events@3.3.0 (git://github.com/Gozala/events.git)
+249.  bpmn-moddle@9.0.4 (https://github.com/bpmn-io/bpmn-moddle)
+250.  moddle@7.2.0 (https://github.com/bpmn-io/moddle)
+251.  moddle-xml@11.0.0 (https://github.com/bpmn-io/moddle-xml)
+252.  saxen@10.0.0 (https://github.com/nikku/saxen)
+253.  dmn-moddle@10.0.0 (https://github.com/bpmn-io/dmn-moddle)
+254.  camunda-bpmn-moddle@7.0.1 (https://github.com/camunda/camunda-bpmn-moddle)
+255.  camunda-dmn-moddle@1.3.1 (https://github.com/camunda/camunda-dmn-moddle)
+256.  zeebe-bpmn-moddle@1.12.0 (https://github.com/camunda/zeebe-bpmn-moddle)
+257.  @sentry/browser@9.47.1 (git://github.com/getsentry/sentry-javascript.git)
+258.  @sentry-internal/feedback@9.47.1 (git://github.com/getsentry/sentry-javascript.git)
+259.  @sentry/core@9.47.1 (git://github.com/getsentry/sentry-javascript.git)
+260.  @sentry-internal/browser-utils@9.47.1 (git://github.com/getsentry/sentry-javascript.git)
+261.  @sentry-internal/replay@9.47.1 (git+https://github.com/getsentry/sentry-javascript.git)
+262.  @sentry-internal/replay-canvas@9.47.1 (git+https://github.com/getsentry/sentry-javascript.git)
+263.  @sentry/integrations@7.114.0 (git://github.com/getsentry/sentry-javascript.git)
+264.  @sentry/utils@7.114.0 (git://github.com/getsentry/sentry-javascript.git)
+265.  ua-parser-js@1.0.41 (https://github.com/faisalman/ua-parser-js.git)
+266.  inherits-browser@0.1.0 (git+https://github.com/nikku/inherits-browser.git)
+267.  object-refs@0.4.0 (https://github.com/bpmn-io/object-refs)
+268.  mixpanel-browser@2.78.0 (https://github.com/mixpanel/mixpanel-js.git)
+269.  p-defer@4.0.1 (sindresorhus/p-defer)
+270.  p-series@3.0.0 (sindresorhus/p-series)
+271.  sourcemapped-stacktrace@1.1.11 (http://github.com/novocaine/sourcemapped-stacktrace)
+272.  @bpmn-io/replace-ids@0.2.0 (git+https://github.com/bpmn-io/replace-ids.git)
+273.  bpmnlint@11.12.0 (https://github.com/bpmn-io/bpmnlint)
+274.  bpmnlint-plugin-camunda-compat@2.48.1 (https://github.com/camunda/bpmnlint-plugin-camunda-compat)
+275.  bpmnlint-utils@1.1.1 (https://github.com/bpmn-io/bpmnlint-utils)
+276.  @bpmn-io/moddle-utils@0.3.0 (https://github.com/bpmn-io/moddle-utils)
+277.  semver-compare@1.0.0 (git://github.com/substack/semver-compare.git)
+278.  modeler-moddle@0.2.0 (https://github.com/camunda/modeler-moddle)
+279.  lezer-feel@1.9.0 (https://github.com/nikku/lezer-feel.git)
+280.  htm@3.1.1 (developit/htm)
+281.  htm_preact@undefined
+282.  @codemirror/search@6.6.0 (git+https://github.com/codemirror/search.git)
+283.  codemirror@6.0.2 (https://github.com/codemirror/basic-setup.git)
+284.  didi@11.0.0 (git://github.com/nikku/didi.git)
+285.  fast-xml-builder@1.1.4 (git+https://github.com/NaturalIntelligence/fast-xml-builder.git)
+286.  fast-xml-parser@5.5.11 (git+https://github.com/NaturalIntelligence/fast-xml-parser.git)
+287.  path-expression-matcher@1.5.0 (https://github.com/NaturalIntelligence/path-expression-matcher)
+288.  strnum@2.2.3 (https://github.com/NaturalIntelligence/strnum)
+289.  @bpmn-io/add-exporter@0.2.0 (git+ssh://git@github.com/bpmn-io/add-exporter.git)
+290.  @bpmn-io/variable-resolver@3.0.0 (https://github.com/bpmn-io/variable-resolver)
+291.  bpmn-js-color-picker@0.7.2 (https://github.com/bpmn-io/bpmn-js-color-picker.git)
+292.  bpmn-js-create-append-anything@1.2.0 (git+https://github.com/bpmn-io/bpmn-js-create-append-anything.git)
+293.  bpmn-js-element-templates@2.23.0 (https://github.com/bpmn-io/bpmn-js-element-templates)
+294.  semver@7.7.4 (git+https://github.com/npm/node-semver.git)
+295.  bpmn-js-executable-fix@0.2.1 (git+https://github.com/bpmn-io/bpmn-js-executable-fix.git)
+296.  bpmn-js-native-copy-paste@0.3.0 (git+https://github.com/nikku/bpmn-js-native-copy-paste.git)
+297.  bpmn-js-tracking@0.6.0 (git+https://github.com/bpmn-io/bpmn-js-tracking.git)
+298.  camunda-bpmn-js-behaviors@1.14.1 (https://github.com/camunda/camunda-bpmn-js-behaviors)
+299.  diagram-js-minimap@5.3.0 (git@github.com:bpmn-io/diagram-js-minimap.git)
+300.  @bpmn-io/align-to-origin@0.7.0 (git+ssh://git@github.com/bpmn-io/align-to-origin.git)
+301.  @camunda/improved-canvas@1.8.0 (git+https://github.com/camunda/improved-canvas.git)
+302.  diagram-js-direct-editing@3.3.0 (https://github.com/bpmn-io/diagram-js-direct-editing)
+303.  diagram-js-origin@1.4.0 (https://github.com/bpmn-io/diagram-js-origin)
+304.  tiny-svg@3.1.3 (https://github.com/bpmn-io/tiny-svg)
+305.  performance-now@2.1.0 (git://github.com/braveg1rl/performance-now.git)
+306.  raf@3.4.1 (git://github.com/chrisdickinson/raf.git)
+307.  rgbcolor@1.0.1 (https://github.com/yetzt/node-rgbcolor.git)
+308.  stackblur-canvas@2.7.0 (https://github.com/flozz/StackBlur.git)
+309.  @bpmn-io/dmn-migrate@0.5.0 (git+https://github.com/bpmn-io/dmn-migrate.git)
+310.  @bpmn-io/dmn-variable-resolver@0.7.0
+311.  @camunda/execution-platform@0.3.2 (git+ssh://git@github.com/camunda/execution-platform.git)
+312.  css.escape@1.5.1 (https://github.com/mathiasbynens/CSS.escape.git)
+313.  dmn-js-boxed-expression@17.7.0 (https://github.com/bpmn-io/dmn-js)
+314.  dmn-js-decision-table@17.7.0 (https://github.com/bpmn-io/dmn-js)
+315.  dmn-js-drd@17.7.0 (https://github.com/bpmn-io/dmn-js)
+316.  dmn-js-literal-expression@17.7.0 (https://github.com/bpmn-io/dmn-js)
+317.  dmn-js-shared@17.7.0 (https://github.com/bpmn-io/dmn-js)
+318.  dmn-js@17.7.0 (https://github.com/bpmn-io/dmn-js)
+319.  escape-html@1.0.3 (component/escape-html)
+320.  inferno@5.6.3 (https://github.com/infernojs/inferno)
+321.  table-js@9.4.0 (https://github.com/bpmn-io/table-js)
+322.  @bpmn-io/form-js-editor@1.21.2 (git+https://github.com/bpmn-io/form-js.git)
+323.  @bpmn-io/form-js-playground@1.21.2 (git+https://github.com/bpmn-io/form-js.git)
+324.  @bpmn-io/form-js-viewer@1.21.2 (git+https://github.com/bpmn-io/form-js.git)
+325.  downloadjs@1.4.7 (https://github.com/rndme/download.git)
+326.  flatpickr@4.6.13 (git+https://github.com/chmln/flatpickr.git)
+327.  lodash@4.18.1 (lodash/lodash)
+328.  @codemirror/lang-xml@6.1.0 (https://github.com/codemirror/lang-xml.git)
+329.  @lezer/xml@1.0.6 (https://github.com/lezer-parser/xml.git)
+330.  canvg@4.0.3 (https://github.com/canvg/canvg)
+331.  clsx@2.1.1 (lukeed/clsx)
+332.  diagram-js-grid@2.0.1 (git@github.com:bpmn-io/diagram-js-grid.git)
+333.  path-intersection@4.1.0 (https://github.com/bpmn-io/path-intersection)
+334.  svg-pathdata@6.0.3 (https://github.com/nfroidure/svg-pathdata.git)
+335.  selection-update@1.1.1 (git+ssh://git@github.com/nikku/selection-update.git)
+336.  selection-ranges@4.1.1 (git+ssh://git@github.com/nikku/selection-ranges.git)
+337.  zeebe-dmn-moddle@1.0.0 (https://github.com/camunda/zeebe-dmn-moddle)
+338.  @bpmn-io/element-templates-validator@2.20.1 (git+https://github.com/bpmn-io/element-templates-validator.git)
+339.  @bpmn-io/feel-analyzer@0.1.0 (git+https://github.com/bpmn-io/feel-analyzer.git)
+340.  @bpmn-io/svg-to-image@1.0.1 (git+https://github.com/bpmn-io/svg-to-image.git)
+341.  bpmn-js-copy-as-image@0.4.1 (git+https://github.com/barmac/bpmn-js-copy-as-image.git)
+342.  uuid@13.0.0 (https://github.com/uuidjs/uuid.git)
+343.  @bpmn-io/draggle@4.1.2 (https://github.com/bpmn-io/draggle.git)
+344.  @codemirror/lang-json@6.0.2 (https://github.com/codemirror/lang-json.git)
+345.  @lezer/json@1.0.3 (https://github.com/lezer-parser/json.git)
+346.  big.js@7.0.1 (https://github.com/MikeMcl/big.js.git)
+347.  dompurify@3.3.3 (git://github.com/cure53/DOMPurify.git)
+348.  file-drops@0.7.0 (git+ssh://git@github.com/nikku/file-drops.git)
+349.  marked@17.0.6 (git://github.com/markedjs/marked.git)
+350.  vscode-windows-ca-certs@0.3.0 (git+https://github.com/Microsoft/vscode-windows-ca-certs.git)
 
 
-%% @sentry/node@9.0.0 NOTICES AND INFORMATION BEGIN HERE
+%% @sentry/node@9.47.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -380,10 +382,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF @sentry/node@9.0.0 NOTICES AND INFORMATION
+END OF @sentry/node@9.47.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/api@1.9.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/api@1.9.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -588,10 +590,10 @@ END OF @sentry/node@9.0.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/api@1.9.0 NOTICES AND INFORMATION
+END OF @opentelemetry/api@1.9.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-http@0.57.1 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-http@0.57.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -796,7 +798,7 @@ END OF @opentelemetry/api@1.9.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-http@0.57.1 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-http@0.57.2 NOTICES AND INFORMATION
 
 
 %% @opentelemetry/core@1.30.1 NOTICES AND INFORMATION BEGIN HERE
@@ -1215,7 +1217,7 @@ END OF @opentelemetry/core@1.30.1 NOTICES AND INFORMATION
 END OF @opentelemetry/semantic-conventions@1.28.0 NOTICES AND INFORMATION
 
 
-%% semver@7.6.2 NOTICES AND INFORMATION BEGIN HERE
+%% semver@7.7.4 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The ISC License
 
@@ -1234,10 +1236,10 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ==========================================
-END OF semver@7.6.2 NOTICES AND INFORMATION
+END OF semver@7.7.4 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation@0.57.1 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation@0.57.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -1442,10 +1444,10 @@ END OF semver@7.6.2 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation@0.57.1 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation@0.57.2 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/api-logs@0.57.1 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/api-logs@0.57.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -1650,7 +1652,7 @@ END OF @opentelemetry/instrumentation@0.57.1 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/api-logs@0.57.1 NOTICES AND INFORMATION
+END OF @opentelemetry/api-logs@0.57.2 NOTICES AND INFORMATION
 
 
 %% shimmer@1.2.1 NOTICES AND INFORMATION BEGIN HERE
@@ -1685,12 +1687,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 END OF shimmer@1.2.1 NOTICES AND INFORMATION
 
 
-%% require-in-the-middle@7.3.0 NOTICES AND INFORMATION BEGIN HERE
+%% require-in-the-middle@7.5.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
 Copyright (c) 2016-2019, Thomas Watson Steen
-Copyright (c) 2019-2023, Elasticsearch B.V.
+Copyright (c) 2019-2025, Elasticsearch B.V.
+Copyright (c) 2025+, require-in-the-middle contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1711,10 +1714,125 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF require-in-the-middle@7.3.0 NOTICES AND INFORMATION
+END OF require-in-the-middle@7.5.2 NOTICES AND INFORMATION
 
 
-%% resolve@1.22.11 NOTICES AND INFORMATION BEGIN HERE
+%% debug@4.4.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(The MIT License)
+
+Copyright (c) 2014-2017 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2018-2021 Josh Junon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the 'Software'), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+==========================================
+END OF debug@4.4.3 NOTICES AND INFORMATION
+
+
+%% ms@2.1.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2020 Vercel, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF ms@2.1.3 NOTICES AND INFORMATION
+
+
+%% supports-color@7.2.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF supports-color@7.2.0 NOTICES AND INFORMATION
+
+
+%% has-flag@4.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF has-flag@4.0.0 NOTICES AND INFORMATION
+
+
+%% module-details-from-path@1.0.4 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2016-2025 Thomas Watson Steen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF module-details-from-path@1.0.4 NOTICES AND INFORMATION
+
+
+%% resolve@1.22.12 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -1739,7 +1857,35 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF resolve@1.22.11 NOTICES AND INFORMATION
+END OF resolve@1.22.12 NOTICES AND INFORMATION
+
+
+%% es-errors@1.3.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF es-errors@1.3.0 NOTICES AND INFORMATION
 
 
 %% path-parse@1.0.7 NOTICES AND INFORMATION BEGIN HERE
@@ -1851,122 +1997,7 @@ THE SOFTWARE.
 END OF function-bind@1.1.2 NOTICES AND INFORMATION
 
 
-%% debug@4.3.7 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-(The MIT License)
-
-Copyright (c) 2014-2017 TJ Holowaychuk <tj@vision-media.ca>
-Copyright (c) 2018-2021 Josh Junon
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software
-and associated documentation files (the 'Software'), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial
-portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-==========================================
-END OF debug@4.3.7 NOTICES AND INFORMATION
-
-
-%% ms@2.1.3 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-The MIT License (MIT)
-
-Copyright (c) 2020 Vercel, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-==========================================
-END OF ms@2.1.3 NOTICES AND INFORMATION
-
-
-%% supports-color@5.5.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-MIT License
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-==========================================
-END OF supports-color@5.5.0 NOTICES AND INFORMATION
-
-
-%% has-flag@3.0.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-MIT License
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-==========================================
-END OF has-flag@3.0.0 NOTICES AND INFORMATION
-
-
-%% module-details-from-path@1.0.3 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-The MIT License (MIT)
-
-Copyright (c) 2016 Thomas Watson Steen
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-==========================================
-END OF module-details-from-path@1.0.3 NOTICES AND INFORMATION
-
-
-%% import-in-the-middle@1.13.0 NOTICES AND INFORMATION BEGIN HERE
+%% import-in-the-middle@1.15.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -2171,7 +2202,7 @@ END OF module-details-from-path@1.0.3 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF import-in-the-middle@1.13.0 NOTICES AND INFORMATION
+END OF import-in-the-middle@1.15.0 NOTICES AND INFORMATION
 
 
 %% forwarded-parse@2.1.2 NOTICES AND INFORMATION BEGIN HERE
@@ -2200,7 +2231,7 @@ THE SOFTWARE.
 END OF forwarded-parse@2.1.2 NOTICES AND INFORMATION
 
 
-%% @sentry/core@9.0.0 NOTICES AND INFORMATION BEGIN HERE
+%% @sentry/core@9.47.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -2225,218 +2256,38 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF @sentry/core@9.0.0 NOTICES AND INFORMATION
+END OF @sentry/core@9.47.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-undici@0.10.0 NOTICES AND INFORMATION BEGIN HERE
+%% @sentry/node-core@9.47.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2025 Functional Software, Inc. dba Sentry
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ==========================================
-END OF @opentelemetry/instrumentation-undici@0.10.0 NOTICES AND INFORMATION
+END OF @sentry/node-core@9.47.1 NOTICES AND INFORMATION
 
 
-%% @sentry/opentelemetry@9.0.0 NOTICES AND INFORMATION BEGIN HERE
+%% @sentry/opentelemetry@9.47.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -2461,7 +2312,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF @sentry/opentelemetry@9.0.0 NOTICES AND INFORMATION
+END OF @sentry/opentelemetry@9.47.1 NOTICES AND INFORMATION
 
 
 %% @opentelemetry/sdk-trace-base@1.30.1 NOTICES AND INFORMATION BEGIN HERE
@@ -2880,7 +2731,7 @@ END OF @opentelemetry/sdk-trace-base@1.30.1 NOTICES AND INFORMATION
 END OF @opentelemetry/resources@1.30.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-fs@0.19.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/context-async-hooks@1.30.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -3085,10 +2936,10 @@ END OF @opentelemetry/resources@1.30.1 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-fs@0.19.0 NOTICES AND INFORMATION
+END OF @opentelemetry/context-async-hooks@1.30.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-express@0.47.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-undici@0.10.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -3293,10 +3144,10 @@ END OF @opentelemetry/instrumentation-fs@0.19.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-express@0.47.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-undici@0.10.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-fastify@0.44.1 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-fs@0.19.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -3501,10 +3352,10 @@ END OF @opentelemetry/instrumentation-express@0.47.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-fastify@0.44.1 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-fs@0.19.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-graphql@0.47.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-express@0.47.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -3709,10 +3560,88 @@ END OF @opentelemetry/instrumentation-fastify@0.44.1 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-graphql@0.47.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-express@0.47.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-kafkajs@0.7.0 NOTICES AND INFORMATION BEGIN HERE
+%% minimatch@9.0.9 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The ISC License
+
+Copyright (c) 2011-2023 Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+==========================================
+END OF minimatch@9.0.9 NOTICES AND INFORMATION
+
+
+%% brace-expansion@2.1.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) 2013 Julian Gruber <julian@juliangruber.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF brace-expansion@2.1.0 NOTICES AND INFORMATION
+
+
+%% balanced-match@1.0.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+(MIT)
+
+Copyright (c) 2013 Julian Gruber &lt;julian@juliangruber.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF balanced-match@1.0.2 NOTICES AND INFORMATION
+
+
+%% @opentelemetry/instrumentation-graphql@0.47.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -3917,10 +3846,10 @@ END OF @opentelemetry/instrumentation-graphql@0.47.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-kafkajs@0.7.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-graphql@0.47.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-lru-memoizer@0.44.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-kafkajs@0.7.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -4125,10 +4054,10 @@ END OF @opentelemetry/instrumentation-kafkajs@0.7.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-lru-memoizer@0.44.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-kafkajs@0.7.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-mongodb@0.51.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-lru-memoizer@0.44.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -4333,10 +4262,10 @@ END OF @opentelemetry/instrumentation-lru-memoizer@0.44.0 NOTICES AND INFORMATIO
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-mongodb@0.51.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-lru-memoizer@0.44.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-mongoose@0.46.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-mongodb@0.52.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -4541,10 +4470,10 @@ END OF @opentelemetry/instrumentation-mongodb@0.51.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-mongoose@0.46.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-mongodb@0.52.0 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-mysql@0.45.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-mongoose@0.46.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -4749,10 +4678,10 @@ END OF @opentelemetry/instrumentation-mongoose@0.46.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-mysql@0.45.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-mongoose@0.46.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-mysql2@0.45.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-mysql@0.45.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -4957,7 +4886,215 @@ END OF @opentelemetry/instrumentation-mysql@0.45.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-mysql2@0.45.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-mysql@0.45.1 NOTICES AND INFORMATION
+
+
+%% @opentelemetry/instrumentation-mysql2@0.45.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+==========================================
+END OF @opentelemetry/instrumentation-mysql2@0.45.2 NOTICES AND INFORMATION
 
 
 %% @opentelemetry/sql-common@0.40.1 NOTICES AND INFORMATION BEGIN HERE
@@ -5168,7 +5305,7 @@ END OF @opentelemetry/instrumentation-mysql2@0.45.0 NOTICES AND INFORMATION
 END OF @opentelemetry/sql-common@0.40.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-ioredis@0.47.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-ioredis@0.47.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -5373,7 +5510,7 @@ END OF @opentelemetry/sql-common@0.40.1 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-ioredis@0.47.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-ioredis@0.47.1 NOTICES AND INFORMATION
 
 
 %% @opentelemetry/redis-common@0.36.2 NOTICES AND INFORMATION BEGIN HERE
@@ -5584,7 +5721,7 @@ END OF @opentelemetry/instrumentation-ioredis@0.47.0 NOTICES AND INFORMATION
 END OF @opentelemetry/redis-common@0.36.2 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-redis-4@0.46.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-redis-4@0.46.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -5789,10 +5926,10 @@ END OF @opentelemetry/redis-common@0.36.2 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-redis-4@0.46.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-redis-4@0.46.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-pg@0.50.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-pg@0.51.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -5997,10 +6134,10 @@ END OF @opentelemetry/instrumentation-redis-4@0.46.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-pg@0.50.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-pg@0.51.1 NOTICES AND INFORMATION
 
 
-%% @prisma/instrumentation@6.2.1 NOTICES AND INFORMATION BEGIN HERE
+%% @prisma/instrumentation@6.11.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -6205,10 +6342,10 @@ END OF @opentelemetry/instrumentation-pg@0.50.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @prisma/instrumentation@6.2.1 NOTICES AND INFORMATION
+END OF @prisma/instrumentation@6.11.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-hapi@0.45.1 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-hapi@0.45.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -6413,10 +6550,10 @@ END OF @prisma/instrumentation@6.2.1 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-hapi@0.45.1 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-hapi@0.45.2 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-koa@0.47.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-koa@0.47.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -6621,10 +6758,10 @@ END OF @opentelemetry/instrumentation-hapi@0.45.1 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-koa@0.47.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-koa@0.47.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-connect@0.43.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-connect@0.43.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -6829,10 +6966,10 @@ END OF @opentelemetry/instrumentation-koa@0.47.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-connect@0.43.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-connect@0.43.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-knex@0.44.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-knex@0.44.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -7037,10 +7174,10 @@ END OF @opentelemetry/instrumentation-connect@0.43.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-knex@0.44.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-knex@0.44.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-tedious@0.18.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-tedious@0.18.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -7245,10 +7382,10 @@ END OF @opentelemetry/instrumentation-knex@0.44.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-tedious@0.18.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-tedious@0.18.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-generic-pool@0.43.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-generic-pool@0.43.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -7453,10 +7590,10 @@ END OF @opentelemetry/instrumentation-tedious@0.18.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-generic-pool@0.43.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-generic-pool@0.43.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-dataloader@0.16.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-dataloader@0.16.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -7661,10 +7798,10 @@ END OF @opentelemetry/instrumentation-generic-pool@0.43.0 NOTICES AND INFORMATIO
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-dataloader@0.16.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-dataloader@0.16.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/instrumentation-amqplib@0.46.0 NOTICES AND INFORMATION BEGIN HERE
+%% @opentelemetry/instrumentation-amqplib@0.46.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -7869,218 +8006,10 @@ END OF @opentelemetry/instrumentation-dataloader@0.16.0 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @opentelemetry/instrumentation-amqplib@0.46.0 NOTICES AND INFORMATION
+END OF @opentelemetry/instrumentation-amqplib@0.46.1 NOTICES AND INFORMATION
 
 
-%% @opentelemetry/context-async-hooks@1.30.1 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-==========================================
-END OF @opentelemetry/context-async-hooks@1.30.1 NOTICES AND INFORMATION
-
-
-%% @camunda8/sdk@8.8.7 NOTICES AND INFORMATION BEGIN HERE
+%% @camunda8/sdk@8.8.9 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -8284,7 +8213,7 @@ END OF @opentelemetry/context-async-hooks@1.30.1 NOTICES AND INFORMATION
    See the License for the specific language governing permissions and
    limitations under the License.
 ==========================================
-END OF @camunda8/sdk@8.8.7 NOTICES AND INFORMATION
+END OF @camunda8/sdk@8.8.9 NOTICES AND INFORMATION
 
 
 %% got@11.8.6 NOTICES AND INFORMATION BEGIN HERE
@@ -8419,7 +8348,7 @@ SOFTWARE.
 END OF cacheable-lookup@5.0.4 NOTICES AND INFORMATION
 
 
-%% cacheable-request@7.0.2 NOTICES AND INFORMATION BEGIN HERE
+%% cacheable-request@7.0.4 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -8444,7 +8373,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF cacheable-request@7.0.2 NOTICES AND INFORMATION
+END OF cacheable-request@7.0.4 NOTICES AND INFORMATION
 
 
 %% normalize-url@6.1.0 NOTICES AND INFORMATION BEGIN HERE
@@ -8479,7 +8408,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 END OF get-stream@5.2.0 NOTICES AND INFORMATION
 
 
-%% pump@3.0.0 NOTICES AND INFORMATION BEGIN HERE
+%% pump@3.0.4 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -8503,7 +8432,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF pump@3.0.0 NOTICES AND INFORMATION
+END OF pump@3.0.4 NOTICES AND INFORMATION
 
 
 %% once@1.4.0 NOTICES AND INFORMATION BEGIN HERE
@@ -8550,7 +8479,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 END OF wrappy@1.0.2 NOTICES AND INFORMATION
 
 
-%% end-of-stream@1.4.1 NOTICES AND INFORMATION BEGIN HERE
+%% end-of-stream@1.4.5 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -8574,10 +8503,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF end-of-stream@1.4.1 NOTICES AND INFORMATION
+END OF end-of-stream@1.4.5 NOTICES AND INFORMATION
 
 
-%% http-cache-semantics@4.1.1 NOTICES AND INFORMATION BEGIN HERE
+%% http-cache-semantics@4.2.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright 2016-2018 Kornel Lesiński
 
@@ -8590,7 +8519,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ==========================================
-END OF http-cache-semantics@4.1.1 NOTICES AND INFORMATION
+END OF http-cache-semantics@4.2.0 NOTICES AND INFORMATION
 
 
 %% responselike@2.0.1 NOTICES AND INFORMATION BEGIN HERE
@@ -8936,7 +8865,7 @@ SOFTWARE.
 END OF jwt-decode@4.0.0 NOTICES AND INFORMATION
 
 
-%% winston@3.17.0 NOTICES AND INFORMATION BEGIN HERE
+%% winston@3.19.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2010 Charlie Robbins
 
@@ -8958,7 +8887,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF winston@3.17.0 NOTICES AND INFORMATION
+END OF winston@3.19.0 NOTICES AND INFORMATION
 
 
 %% logform@2.7.0 NOTICES AND INFORMATION BEGIN HERE
@@ -9353,7 +9282,7 @@ THE SOFTWARE.
 END OF async@3.2.6 NOTICES AND INFORMATION
 
 
-%% @dabh/diagnostics@2.0.3 NOTICES AND INFORMATION BEGIN HERE
+%% @dabh/diagnostics@2.0.8 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -9377,10 +9306,10 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF @dabh/diagnostics@2.0.3 NOTICES AND INFORMATION
+END OF @dabh/diagnostics@2.0.8 NOTICES AND INFORMATION
 
 
-%% colorspace@1.1.4 NOTICES AND INFORMATION BEGIN HERE
+%% @so-ric/colorspace@1.1.6 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -9404,189 +9333,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF colorspace@1.1.4 NOTICES AND INFORMATION
-
-
-%% color@3.2.1 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-Copyright (c) 2012 Heather Arthur
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-==========================================
-END OF color@3.2.1 NOTICES AND INFORMATION
-
-
-%% color-string@1.9.1 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-Copyright (c) 2011 Heather Arthur <fayearthur@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-==========================================
-END OF color-string@1.9.1 NOTICES AND INFORMATION
-
-
-%% color-name@1.1.3 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-The MIT License (MIT)
-Copyright (c) 2015 Dmitry Ivanov
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-==========================================
-END OF color-name@1.1.3 NOTICES AND INFORMATION
-
-
-%% simple-swizzle@0.2.2 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-The MIT License (MIT)
-
-Copyright (c) 2015 Josh Junon
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-==========================================
-END OF simple-swizzle@0.2.2 NOTICES AND INFORMATION
-
-
-%% is-arrayish@0.3.2 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-The MIT License (MIT)
-
-Copyright (c) 2015 JD Ballard
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-==========================================
-END OF is-arrayish@0.3.2 NOTICES AND INFORMATION
-
-
-%% color-convert@1.9.3 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-==========================================
-END OF color-convert@1.9.3 NOTICES AND INFORMATION
-
-
-%% text-hex@1.0.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-The MIT License (MIT)
-
-Copyright (c) 2014-2015 Arnout Kazemier <opensource@3rd-Eden.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-==========================================
-END OF text-hex@1.0.0 NOTICES AND INFORMATION
+END OF @so-ric/colorspace@1.1.6 NOTICES AND INFORMATION
 
 
 %% kuler@2.0.0 NOTICES AND INFORMATION BEGIN HERE
@@ -9786,7 +9533,7 @@ SOFTWARE.
 END OF is-electron@2.2.2 NOTICES AND INFORMATION
 
 
-%% node-forge@1.3.3 NOTICES AND INFORMATION BEGIN HERE
+%% node-forge@1.4.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 You may use the Forge project under the terms of either the BSD License or the
 GNU General Public License (GPL) Version 2.
@@ -10121,7 +9868,7 @@ POSSIBILITY OF SUCH DAMAGES.
 
 
 ==========================================
-END OF node-forge@1.3.3 NOTICES AND INFORMATION
+END OF node-forge@1.4.0 NOTICES AND INFORMATION
 
 
 %% split@1.0.1 NOTICES AND INFORMATION BEGIN HERE
@@ -10206,7 +9953,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 END OF pify@3.0.0 NOTICES AND INFORMATION
 
 
-%% lossless-json@4.0.2 NOTICES AND INFORMATION BEGIN HERE
+%% lossless-json@4.3.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -10219,7 +9966,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF lossless-json@4.0.2 NOTICES AND INFORMATION
+END OF lossless-json@4.3.0 NOTICES AND INFORMATION
 
 
 %% reflect-metadata@0.2.2 NOTICES AND INFORMATION BEGIN HERE
@@ -10386,7 +10133,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO
 END OF typed-duration@1.0.13 NOTICES AND INFORMATION
 
 
-%% fast-xml-parser@5.5.6 NOTICES AND INFORMATION BEGIN HERE
+%% fast-xml-parser@5.5.11 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -10411,10 +10158,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF fast-xml-parser@5.5.6 NOTICES AND INFORMATION
+END OF fast-xml-parser@5.5.11 NOTICES AND INFORMATION
 
 
-%% dayjs@1.11.5 NOTICES AND INFORMATION BEGIN HERE
+%% dayjs@1.11.20 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -10439,7 +10186,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF dayjs@1.11.5 NOTICES AND INFORMATION
+END OF dayjs@1.11.20 NOTICES AND INFORMATION
 
 
 %% chalk@2.4.2 NOTICES AND INFORMATION BEGIN HERE
@@ -10500,6 +10247,48 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ==========================================
 END OF ansi-styles@3.2.1 NOTICES AND INFORMATION
+
+
+%% color-convert@1.9.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+==========================================
+END OF color-convert@1.9.3 NOTICES AND INFORMATION
+
+
+%% color-name@1.1.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+Copyright (c) 2015 Dmitry Ivanov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==========================================
+END OF color-name@1.1.3 NOTICES AND INFORMATION
 
 
 %% promise-retry@1.1.1 NOTICES AND INFORMATION BEGIN HERE
@@ -10563,7 +10352,7 @@ Felix Geisendörfer (felix@debuggable.com)
 END OF retry@0.10.1 NOTICES AND INFORMATION
 
 
-%% @grpc/grpc-js@1.12.5 NOTICES AND INFORMATION BEGIN HERE
+%% @grpc/grpc-js@1.14.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -10768,7 +10557,7 @@ END OF retry@0.10.1 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @grpc/grpc-js@1.12.5 NOTICES AND INFORMATION
+END OF @grpc/grpc-js@1.14.3 NOTICES AND INFORMATION
 
 
 %% @js-sdsl/ordered-map@4.4.2 NOTICES AND INFORMATION BEGIN HERE
@@ -10799,7 +10588,7 @@ SOFTWARE.
 END OF @js-sdsl/ordered-map@4.4.2 NOTICES AND INFORMATION
 
 
-%% @grpc/proto-loader@0.7.13 NOTICES AND INFORMATION BEGIN HERE
+%% @grpc/proto-loader@0.8.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
                                  Apache License
                            Version 2.0, January 2004
@@ -11004,7 +10793,7 @@ END OF @js-sdsl/ordered-map@4.4.2 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF @grpc/proto-loader@0.7.13 NOTICES AND INFORMATION
+END OF @grpc/proto-loader@0.8.0 NOTICES AND INFORMATION
 
 
 %% lodash.camelcase@4.3.0 NOTICES AND INFORMATION BEGIN HERE
@@ -11061,7 +10850,7 @@ terms above.
 END OF lodash.camelcase@4.3.0 NOTICES AND INFORMATION
 
 
-%% protobufjs@7.2.5 NOTICES AND INFORMATION BEGIN HERE
+%% protobufjs@7.6.4 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 This license applies to all parts of protobuf.js except those files
 either explicitly including or referencing a different license or
@@ -11104,7 +10893,7 @@ standalone and requires a support library to be linked with it. This
 support library is itself covered by the above license.
 
 ==========================================
-END OF protobufjs@7.2.5 NOTICES AND INFORMATION
+END OF protobufjs@7.6.4 NOTICES AND INFORMATION
 
 
 %% @protobufjs/aspromise@1.1.2 NOTICES AND INFORMATION BEGIN HERE
@@ -11173,7 +10962,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 END OF @protobufjs/base64@1.1.2 NOTICES AND INFORMATION
 
 
-%% @protobufjs/eventemitter@1.1.0 NOTICES AND INFORMATION BEGIN HERE
+%% @protobufjs/eventemitter@1.1.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2016, Daniel Wirtz  All rights reserved.
 
@@ -11203,7 +10992,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ==========================================
-END OF @protobufjs/eventemitter@1.1.0 NOTICES AND INFORMATION
+END OF @protobufjs/eventemitter@1.1.1 NOTICES AND INFORMATION
 
 
 %% @protobufjs/float@1.0.2 NOTICES AND INFORMATION BEGIN HERE
@@ -11239,7 +11028,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 END OF @protobufjs/float@1.0.2 NOTICES AND INFORMATION
 
 
-%% @protobufjs/inquire@1.1.0 NOTICES AND INFORMATION BEGIN HERE
+%% @protobufjs/utf8@1.1.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2016, Daniel Wirtz  All rights reserved.
 
@@ -11269,40 +11058,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ==========================================
-END OF @protobufjs/inquire@1.1.0 NOTICES AND INFORMATION
-
-
-%% @protobufjs/utf8@1.1.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-Copyright (c) 2016, Daniel Wirtz  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
-* Neither the name of its author, nor the names of its contributors
-  may be used to endorse or promote products derived from this software
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-==========================================
-END OF @protobufjs/utf8@1.1.0 NOTICES AND INFORMATION
+END OF @protobufjs/utf8@1.1.1 NOTICES AND INFORMATION
 
 
 %% @protobufjs/pool@1.1.0 NOTICES AND INFORMATION BEGIN HERE
@@ -11338,106 +11094,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 END OF @protobufjs/pool@1.1.0 NOTICES AND INFORMATION
 
 
-%% @protobufjs/codegen@2.0.4 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-Copyright (c) 2016, Daniel Wirtz  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
-* Neither the name of its author, nor the names of its contributors
-  may be used to endorse or promote products derived from this software
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-==========================================
-END OF @protobufjs/codegen@2.0.4 NOTICES AND INFORMATION
-
-
-%% @protobufjs/fetch@1.1.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-Copyright (c) 2016, Daniel Wirtz  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
-* Neither the name of its author, nor the names of its contributors
-  may be used to endorse or promote products derived from this software
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-==========================================
-END OF @protobufjs/fetch@1.1.0 NOTICES AND INFORMATION
-
-
-%% @protobufjs/path@1.1.2 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-Copyright (c) 2016, Daniel Wirtz  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
-* Neither the name of its author, nor the names of its contributors
-  may be used to endorse or promote products derived from this software
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-==========================================
-END OF @protobufjs/path@1.1.2 NOTICES AND INFORMATION
-
-
-%% long@5.2.4 NOTICES AND INFORMATION BEGIN HERE
+%% long@5.3.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 
                                  Apache License
@@ -11643,7 +11300,106 @@ END OF @protobufjs/path@1.1.2 NOTICES AND INFORMATION
    limitations under the License.
 
 ==========================================
-END OF long@5.2.4 NOTICES AND INFORMATION
+END OF long@5.3.2 NOTICES AND INFORMATION
+
+
+%% @protobufjs/codegen@2.0.5 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright (c) 2016, Daniel Wirtz  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of its author, nor the names of its contributors
+  may be used to endorse or promote products derived from this software
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+==========================================
+END OF @protobufjs/codegen@2.0.5 NOTICES AND INFORMATION
+
+
+%% @protobufjs/fetch@1.1.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright (c) 2016, Daniel Wirtz  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of its author, nor the names of its contributors
+  may be used to endorse or promote products derived from this software
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+==========================================
+END OF @protobufjs/fetch@1.1.1 NOTICES AND INFORMATION
+
+
+%% @protobufjs/path@1.1.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright (c) 2016, Daniel Wirtz  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of its author, nor the names of its contributors
+  may be used to endorse or promote products derived from this software
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+==========================================
+END OF @protobufjs/path@1.1.2 NOTICES AND INFORMATION
 
 
 %% form-data@4.0.5 NOTICES AND INFORMATION BEGIN HERE
@@ -11894,34 +11650,6 @@ SOFTWARE.
 
 ==========================================
 END OF es-object-atoms@1.1.1 NOTICES AND INFORMATION
-
-
-%% es-errors@1.3.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-MIT License
-
-Copyright (c) 2024 Jordan Harband
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-==========================================
-END OF es-errors@1.3.0 NOTICES AND INFORMATION
 
 
 %% math-intrinsics@1.1.0 NOTICES AND INFORMATION BEGIN HERE
@@ -12176,7 +11904,7 @@ THE SOFTWARE.
 END OF mri@1.2.0 NOTICES AND INFORMATION
 
 
-%% min-dash@4.2.1 NOTICES AND INFORMATION BEGIN HERE
+%% min-dash@4.2.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -12200,7 +11928,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF min-dash@4.2.1 NOTICES AND INFORMATION
+END OF min-dash@4.2.3 NOTICES AND INFORMATION
 
 
 %% parents@1.0.1 NOTICES AND INFORMATION BEGIN HERE
@@ -12238,7 +11966,7 @@ This file is pulled directly from Node.js
 END OF path-platform@0.11.15 NOTICES AND INFORMATION
 
 
-%% fast-glob@3.3.2 NOTICES AND INFORMATION BEGIN HERE
+%% fast-glob@3.3.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -12263,7 +11991,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF fast-glob@3.3.2 NOTICES AND INFORMATION
+END OF fast-glob@3.3.3 NOTICES AND INFORMATION
 
 
 %% glob-parent@5.1.2 NOTICES AND INFORMATION BEGIN HERE
@@ -12484,7 +12212,7 @@ THE SOFTWARE.
 END OF is-number@7.0.0 NOTICES AND INFORMATION
 
 
-%% picomatch@2.3.1 NOTICES AND INFORMATION BEGIN HERE
+%% picomatch@2.3.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -12509,7 +12237,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF picomatch@2.3.1 NOTICES AND INFORMATION
+END OF picomatch@2.3.2 NOTICES AND INFORMATION
 
 
 %% merge2@1.4.1 NOTICES AND INFORMATION BEGIN HERE
@@ -12678,7 +12406,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 END OF queue-microtask@1.2.3 NOTICES AND INFORMATION
 
 
-%% fastq@1.13.0 NOTICES AND INFORMATION BEGIN HERE
+%% fastq@1.20.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2015-2020, Matteo Collina <matteo.collina@gmail.com>
 
@@ -12695,14 +12423,14 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ==========================================
-END OF fastq@1.13.0 NOTICES AND INFORMATION
+END OF fastq@1.20.1 NOTICES AND INFORMATION
 
 
-%% reusify@1.0.4 NOTICES AND INFORMATION BEGIN HERE
+%% reusify@1.1.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
-Copyright (c) 2015 Matteo Collina
+Copyright (c) 2015-2024 Matteo Collina
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -12724,7 +12452,7 @@ SOFTWARE.
 
 
 ==========================================
-END OF reusify@1.0.4 NOTICES AND INFORMATION
+END OF reusify@1.1.0 NOTICES AND INFORMATION
 
 
 %% @sentry/integrations@7.114.0 NOTICES AND INFORMATION BEGIN HERE
@@ -13015,7 +12743,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 END OF style-loader@4.0.0 NOTICES AND INFORMATION
 
 
-%% css-loader@7.1.2 NOTICES AND INFORMATION BEGIN HERE
+%% css-loader@7.1.4 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright JS Foundation and other contributors
 
@@ -13039,7 +12767,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF css-loader@7.1.2 NOTICES AND INFORMATION
+END OF css-loader@7.1.4 NOTICES AND INFORMATION
 
 
 %% @camunda/form-playground@0.20.0 NOTICES AND INFORMATION BEGIN HERE
@@ -13069,7 +12797,7 @@ THE SOFTWARE.
 END OF @camunda/form-playground@0.20.0 NOTICES AND INFORMATION
 
 
-%% camunda-bpmn-js@5.6.1 NOTICES AND INFORMATION BEGIN HERE
+%% camunda-bpmn-js@5.26.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -13093,7 +12821,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF camunda-bpmn-js@5.6.1 NOTICES AND INFORMATION
+END OF camunda-bpmn-js@5.26.0 NOTICES AND INFORMATION
 
 
 %% @ibm/plex@6.4.1 NOTICES AND INFORMATION BEGIN HERE
@@ -13196,7 +12924,7 @@ OTHER DEALINGS IN THE FONT SOFTWARE.
 END OF @ibm/plex@6.4.1 NOTICES AND INFORMATION
 
 
-%% camunda-dmn-js@3.1.1 NOTICES AND INFORMATION BEGIN HERE
+%% camunda-dmn-js@3.7.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -13220,10 +12948,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF camunda-dmn-js@3.1.1 NOTICES AND INFORMATION
+END OF camunda-dmn-js@3.7.0 NOTICES AND INFORMATION
 
 
-%% @camunda/linting@3.40.1 NOTICES AND INFORMATION BEGIN HERE
+%% @camunda/linting@3.48.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -13247,10 +12975,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ==========================================
-END OF @camunda/linting@3.40.1 NOTICES AND INFORMATION
+END OF @camunda/linting@3.48.1 NOTICES AND INFORMATION
 
 
-%% min-dash@4.2.2 NOTICES AND INFORMATION BEGIN HERE
+%% min-dash@4.2.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -13274,10 +13002,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF min-dash@4.2.2 NOTICES AND INFORMATION
+END OF min-dash@4.2.3 NOTICES AND INFORMATION
 
 
-%% react@16.14.0 NOTICES AND INFORMATION BEGIN HERE
+%% react@18.3.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -13302,35 +13030,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF react@16.14.0 NOTICES AND INFORMATION
-
-
-%% object-assign@4.1.1 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-The MIT License (MIT)
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-==========================================
-END OF object-assign@4.1.1 NOTICES AND INFORMATION
+END OF react@18.3.1 NOTICES AND INFORMATION
 
 
 %% classnames@2.5.1 NOTICES AND INFORMATION BEGIN HERE
@@ -13361,7 +13061,7 @@ SOFTWARE.
 END OF classnames@2.5.1 NOTICES AND INFORMATION
 
 
-%% react-dom@16.14.0 NOTICES AND INFORMATION BEGIN HERE
+%% react-dom@18.3.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -13386,10 +13086,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF react-dom@16.14.0 NOTICES AND INFORMATION
+END OF react-dom@18.3.1 NOTICES AND INFORMATION
 
 
-%% scheduler@0.19.1 NOTICES AND INFORMATION BEGIN HERE
+%% scheduler@0.23.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -13414,64 +13114,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF scheduler@0.19.1 NOTICES AND INFORMATION
+END OF scheduler@0.23.2 NOTICES AND INFORMATION
 
 
-%% formik@2.0.4 NOTICES AND INFORMATION BEGIN HERE
+%% formik@2.4.9 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
-MIT License
-
-Copyright (c) 2017 Jared Palmer http://jaredpalmer.com
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
+null
 ==========================================
-END OF formik@2.0.4 NOTICES AND INFORMATION
-
-
-%% react-fast-compare@2.0.4 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-MIT License
-
-Copyright (c) 2018 Formidable Labs
-Copyright (c) 2017 Evgeny Poberezkin
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-==========================================
-END OF react-fast-compare@2.0.4 NOTICES AND INFORMATION
+END OF formik@2.4.9 NOTICES AND INFORMATION
 
 
 %% deepmerge@2.2.1 NOTICES AND INFORMATION BEGIN HERE
@@ -13502,7 +13152,7 @@ THE SOFTWARE.
 END OF deepmerge@2.2.1 NOTICES AND INFORMATION
 
 
-%% lodash-es@4.17.21 NOTICES AND INFORMATION BEGIN HERE
+%% lodash-es@4.18.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
 
@@ -13553,7 +13203,36 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ==========================================
-END OF lodash-es@4.17.21 NOTICES AND INFORMATION
+END OF lodash-es@4.18.1 NOTICES AND INFORMATION
+
+
+%% react-fast-compare@2.0.4 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) 2018 Formidable Labs
+Copyright (c) 2017 Evgeny Poberezkin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF react-fast-compare@2.0.4 NOTICES AND INFORMATION
 
 
 %% tiny-warning@1.0.3 NOTICES AND INFORMATION BEGIN HERE
@@ -13674,7 +13353,7 @@ THE SOFTWARE.
 END OF drag-tabs@2.3.1 NOTICES AND INFORMATION
 
 
-%% min-dom@4.1.0 NOTICES AND INFORMATION BEGIN HERE
+%% min-dom@4.2.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -13699,7 +13378,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF min-dom@4.1.0 NOTICES AND INFORMATION
+END OF min-dom@4.2.1 NOTICES AND INFORMATION
 
 
 %% mitt@3.0.1 NOTICES AND INFORMATION BEGIN HERE
@@ -13729,7 +13408,7 @@ SOFTWARE.
 END OF mitt@3.0.1 NOTICES AND INFORMATION
 
 
-%% @bpmn-io/properties-panel@3.26.2 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/properties-panel@3.40.6 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -13753,7 +13432,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF @bpmn-io/properties-panel@3.26.2 NOTICES AND INFORMATION
+END OF @bpmn-io/properties-panel@3.40.6 NOTICES AND INFORMATION
 
 
 %% preact-hooks@0.1.0 NOTICES AND INFORMATION BEGIN HERE
@@ -13868,7 +13547,24 @@ SOFTWARE.
 END OF jsx-runtime@1.0.0 NOTICES AND INFORMATION
 
 
-%% feelers@1.4.0 NOTICES AND INFORMATION BEGIN HERE
+%% domify@3.0.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) TJ Holowaychuk <tj@tjholowaychuk.com>
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF domify@3.0.0 NOTICES AND INFORMATION
+
+
+%% feelers@1.5.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2023-present Camunda Services GmbH
 
@@ -13888,10 +13584,10 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRA
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 OR OTHER DEALINGS IN THE SOFTWARE.
 ==========================================
-END OF feelers@1.4.0 NOTICES AND INFORMATION
+END OF feelers@1.5.1 NOTICES AND INFORMATION
 
 
-%% @lezer/lr@1.4.2 NOTICES AND INFORMATION BEGIN HERE
+%% @lezer/lr@1.4.8 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -13916,10 +13612,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF @lezer/lr@1.4.2 NOTICES AND INFORMATION
+END OF @lezer/lr@1.4.8 NOTICES AND INFORMATION
 
 
-%% @lezer/common@1.2.3 NOTICES AND INFORMATION BEGIN HERE
+%% @lezer/common@1.5.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -13944,10 +13640,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF @lezer/common@1.2.3 NOTICES AND INFORMATION
+END OF @lezer/common@1.5.2 NOTICES AND INFORMATION
 
 
-%% @lezer/highlight@1.2.1 NOTICES AND INFORMATION BEGIN HERE
+%% @lezer/highlight@1.2.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -13972,10 +13668,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF @lezer/highlight@1.2.1 NOTICES AND INFORMATION
+END OF @lezer/highlight@1.2.3 NOTICES AND INFORMATION
 
 
-%% feelin@3.2.0 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/feelin@6.1.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -13999,10 +13695,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF feelin@3.2.0 NOTICES AND INFORMATION
+END OF @bpmn-io/feelin@6.1.0 NOTICES AND INFORMATION
 
 
-%% luxon@3.5.0 NOTICES AND INFORMATION BEGIN HERE
+%% luxon@3.7.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright 2019 JS Foundation and other contributors
 
@@ -14013,10 +13709,10 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF luxon@3.5.0 NOTICES AND INFORMATION
+END OF luxon@3.7.2 NOTICES AND INFORMATION
 
 
-%% lezer-feel@1.8.1 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/lezer-feel@2.3.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -14041,10 +13737,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF lezer-feel@1.8.1 NOTICES AND INFORMATION
+END OF @bpmn-io/lezer-feel@2.3.1 NOTICES AND INFORMATION
 
 
-%% @codemirror/autocomplete@6.18.4 NOTICES AND INFORMATION BEGIN HERE
+%% @codemirror/autocomplete@6.20.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -14069,10 +13765,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF @codemirror/autocomplete@6.18.4 NOTICES AND INFORMATION
+END OF @codemirror/autocomplete@6.20.1 NOTICES AND INFORMATION
 
 
-%% @codemirror/state@6.5.1 NOTICES AND INFORMATION BEGIN HERE
+%% @codemirror/state@6.6.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -14097,7 +13793,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF @codemirror/state@6.5.1 NOTICES AND INFORMATION
+END OF @codemirror/state@6.6.0 NOTICES AND INFORMATION
 
 
 %% @marijn/find-cluster-break@1.0.2 NOTICES AND INFORMATION BEGIN HERE
@@ -14128,7 +13824,7 @@ THE SOFTWARE.
 END OF @marijn/find-cluster-break@1.0.2 NOTICES AND INFORMATION
 
 
-%% @codemirror/view@6.36.2 NOTICES AND INFORMATION BEGIN HERE
+%% @codemirror/view@6.41.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -14153,10 +13849,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF @codemirror/view@6.36.2 NOTICES AND INFORMATION
+END OF @codemirror/view@6.41.0 NOTICES AND INFORMATION
 
 
-%% style-mod@4.1.0 NOTICES AND INFORMATION BEGIN HERE
+%% style-mod@4.1.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (C) 2018 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -14179,12 +13875,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF style-mod@4.1.0 NOTICES AND INFORMATION
+END OF style-mod@4.1.3 NOTICES AND INFORMATION
 
 
-%% w3c-keyname@2.2.6 NOTICES AND INFORMATION BEGIN HERE
+%% w3c-keyname@2.2.8 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
-Copyright (C) 2016 by Marijn Haverbeke <marijnh@gmail.com> and others
+Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -14205,10 +13901,36 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF w3c-keyname@2.2.6 NOTICES AND INFORMATION
+END OF w3c-keyname@2.2.8 NOTICES AND INFORMATION
 
 
-%% @codemirror/language@6.10.8 NOTICES AND INFORMATION BEGIN HERE
+%% crelt@1.0.6 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright (C) 2020 by Marijn Haverbeke <marijn@haverbeke.berlin>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF crelt@1.0.6 NOTICES AND INFORMATION
+
+
+%% @codemirror/language@6.12.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -14233,10 +13955,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF @codemirror/language@6.10.8 NOTICES AND INFORMATION
+END OF @codemirror/language@6.12.3 NOTICES AND INFORMATION
 
 
-%% @codemirror/commands@6.8.0 NOTICES AND INFORMATION BEGIN HERE
+%% @codemirror/commands@6.10.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -14261,10 +13983,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF @codemirror/commands@6.8.0 NOTICES AND INFORMATION
+END OF @codemirror/commands@6.10.3 NOTICES AND INFORMATION
 
 
-%% @codemirror/lint@6.8.4 NOTICES AND INFORMATION BEGIN HERE
+%% @codemirror/lint@6.9.5 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -14289,36 +14011,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF @codemirror/lint@6.8.4 NOTICES AND INFORMATION
+END OF @codemirror/lint@6.9.5 NOTICES AND INFORMATION
 
 
-%% crelt@1.0.5 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-Copyright (C) 2020 by Marijn Haverbeke <marijnh@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-==========================================
-END OF crelt@1.0.5 NOTICES AND INFORMATION
-
-
-%% @lezer/markdown@1.3.0 NOTICES AND INFORMATION BEGIN HERE
+%% @lezer/markdown@1.6.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -14343,10 +14039,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF @lezer/markdown@1.3.0 NOTICES AND INFORMATION
+END OF @lezer/markdown@1.6.3 NOTICES AND INFORMATION
 
 
-%% @bpmn-io/feel-lint@1.4.0 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/feel-lint@3.1.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -14370,7 +14066,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF @bpmn-io/feel-lint@1.4.0 NOTICES AND INFORMATION
+END OF @bpmn-io/feel-lint@3.1.0 NOTICES AND INFORMATION
 
 
 %% @bpmn-io/cm-theme@0.1.0-alpha.2 NOTICES AND INFORMATION BEGIN HERE
@@ -14396,7 +14092,7 @@ OR OTHER DEALINGS IN THE SOFTWARE.
 END OF @bpmn-io/cm-theme@0.1.0-alpha.2 NOTICES AND INFORMATION
 
 
-%% @bpmn-io/feel-editor@1.10.0 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/feel-editor@2.5.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -14420,10 +14116,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF @bpmn-io/feel-editor@1.10.0 NOTICES AND INFORMATION
+END OF @bpmn-io/feel-editor@2.5.2 NOTICES AND INFORMATION
 
 
-%% lang-feel@2.3.0 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/lang-feel@3.0.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -14448,10 +14144,38 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF lang-feel@2.3.0 NOTICES AND INFORMATION
+END OF @bpmn-io/lang-feel@3.0.0 NOTICES AND INFORMATION
 
 
-%% focus-trap@7.5.2 NOTICES AND INFORMATION BEGIN HERE
+%% @camunda/feel-builtins@1.1.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2025-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF @camunda/feel-builtins@1.1.0 NOTICES AND INFORMATION
+
+
+%% focus-trap@8.0.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -14476,10 +14200,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF focus-trap@7.5.2 NOTICES AND INFORMATION
+END OF focus-trap@8.0.1 NOTICES AND INFORMATION
 
 
-%% tabbable@6.2.0 NOTICES AND INFORMATION BEGIN HERE
+%% tabbable@6.4.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -14505,10 +14229,10 @@ SOFTWARE.
 
 
 ==========================================
-END OF tabbable@6.2.0 NOTICES AND INFORMATION
+END OF tabbable@6.4.0 NOTICES AND INFORMATION
 
 
-%% bpmn-js-properties-panel@5.32.1 NOTICES AND INFORMATION BEGIN HERE
+%% bpmn-js-properties-panel@5.53.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -14532,10 +14256,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF bpmn-js-properties-panel@5.32.1 NOTICES AND INFORMATION
+END OF bpmn-js-properties-panel@5.53.0 NOTICES AND INFORMATION
 
 
-%% bpmn-js@18.3.1 NOTICES AND INFORMATION BEGIN HERE
+%% bpmn-js@18.14.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2014-present Camunda Services GmbH
 
@@ -14562,10 +14286,10 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR TH
 OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF bpmn-js@18.3.1 NOTICES AND INFORMATION
+END OF bpmn-js@18.14.0 NOTICES AND INFORMATION
 
 
-%% diagram-js@15.2.4 NOTICES AND INFORMATION BEGIN HERE
+%% diagram-js@15.11.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -14589,10 +14313,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF diagram-js@15.2.4 NOTICES AND INFORMATION
+END OF diagram-js@15.11.0 NOTICES AND INFORMATION
 
 
-%% ids@1.0.5 NOTICES AND INFORMATION BEGIN HERE
+%% ids@3.0.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -14616,10 +14340,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF ids@1.0.5 NOTICES AND INFORMATION
+END OF ids@3.0.2 NOTICES AND INFORMATION
 
 
-%% @bpmn-io/extract-process-variables@1.0.1 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/extract-process-variables@2.2.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -14643,7 +14367,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF @bpmn-io/extract-process-variables@1.0.1 NOTICES AND INFORMATION
+END OF @bpmn-io/extract-process-variables@2.2.1 NOTICES AND INFORMATION
 
 
 %% array-move@4.0.0 NOTICES AND INFORMATION BEGIN HERE
@@ -14662,7 +14386,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 END OF array-move@4.0.0 NOTICES AND INFORMATION
 
 
-%% dmn-js-properties-panel@3.7.0 NOTICES AND INFORMATION BEGIN HERE
+%% dmn-js-properties-panel@3.11.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -14686,10 +14410,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF dmn-js-properties-panel@3.7.0 NOTICES AND INFORMATION
+END OF dmn-js-properties-panel@3.11.0 NOTICES AND INFORMATION
 
 
-%% debug@4.3.7 NOTICES AND INFORMATION BEGIN HERE
+%% debug@4.4.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 (The MIT License)
 
@@ -14713,7 +14437,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ==========================================
-END OF debug@4.3.7 NOTICES AND INFORMATION
+END OF debug@4.4.3 NOTICES AND INFORMATION
 
 
 %% ms@2.1.3 NOTICES AND INFORMATION BEGIN HERE
@@ -14773,7 +14497,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 END OF events@3.3.0 NOTICES AND INFORMATION
 
 
-%% bpmn-moddle@9.0.1 NOTICES AND INFORMATION BEGIN HERE
+%% bpmn-moddle@9.0.4 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -14797,10 +14521,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF bpmn-moddle@9.0.1 NOTICES AND INFORMATION
+END OF bpmn-moddle@9.0.4 NOTICES AND INFORMATION
 
 
-%% moddle@7.0.0 NOTICES AND INFORMATION BEGIN HERE
+%% moddle@7.2.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -14824,7 +14548,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF moddle@7.0.0 NOTICES AND INFORMATION
+END OF moddle@7.2.0 NOTICES AND INFORMATION
 
 
 %% moddle-xml@11.0.0 NOTICES AND INFORMATION BEGIN HERE
@@ -14937,7 +14661,7 @@ THE SOFTWARE.
 END OF camunda-bpmn-moddle@7.0.1 NOTICES AND INFORMATION
 
 
-%% camunda-dmn-moddle@1.3.0 NOTICES AND INFORMATION BEGIN HERE
+%% camunda-dmn-moddle@1.3.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -14961,10 +14685,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF camunda-dmn-moddle@1.3.0 NOTICES AND INFORMATION
+END OF camunda-dmn-moddle@1.3.1 NOTICES AND INFORMATION
 
 
-%% zeebe-bpmn-moddle@1.9.0 NOTICES AND INFORMATION BEGIN HERE
+%% zeebe-bpmn-moddle@1.12.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -14988,10 +14712,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF zeebe-bpmn-moddle@1.9.0 NOTICES AND INFORMATION
+END OF zeebe-bpmn-moddle@1.12.0 NOTICES AND INFORMATION
 
 
-%% @sentry/browser@9.0.0 NOTICES AND INFORMATION BEGIN HERE
+%% @sentry/browser@9.47.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -15016,122 +14740,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF @sentry/browser@9.0.0 NOTICES AND INFORMATION
+END OF @sentry/browser@9.47.1 NOTICES AND INFORMATION
 
 
-%% @sentry/core@9.0.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-MIT License
-
-Copyright (c) 2019 Functional Software, Inc. dba Sentry
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-==========================================
-END OF @sentry/core@9.0.0 NOTICES AND INFORMATION
-
-
-%% @sentry-internal/browser-utils@9.0.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-MIT License
-
-Copyright (c) 2020 Functional Software, Inc. dba Sentry
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-==========================================
-END OF @sentry-internal/browser-utils@9.0.0 NOTICES AND INFORMATION
-
-
-%% @sentry-internal/replay@9.0.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-MIT License
-
-Copyright (c) 2022 Functional Software, Inc. dba Sentry
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-==========================================
-END OF @sentry-internal/replay@9.0.0 NOTICES AND INFORMATION
-
-
-%% @sentry-internal/replay-canvas@9.0.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-MIT License
-
-Copyright (c) 2024 Functional Software, Inc. dba Sentry
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-==========================================
-END OF @sentry-internal/replay-canvas@9.0.0 NOTICES AND INFORMATION
-
-
-%% @sentry-internal/feedback@9.0.0 NOTICES AND INFORMATION BEGIN HERE
+%% @sentry-internal/feedback@9.47.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -15156,7 +14768,119 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF @sentry-internal/feedback@9.0.0 NOTICES AND INFORMATION
+END OF @sentry-internal/feedback@9.47.1 NOTICES AND INFORMATION
+
+
+%% @sentry/core@9.47.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) 2019 Functional Software, Inc. dba Sentry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF @sentry/core@9.47.1 NOTICES AND INFORMATION
+
+
+%% @sentry-internal/browser-utils@9.47.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) 2020 Functional Software, Inc. dba Sentry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF @sentry-internal/browser-utils@9.47.1 NOTICES AND INFORMATION
+
+
+%% @sentry-internal/replay@9.47.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) 2022 Functional Software, Inc. dba Sentry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF @sentry-internal/replay@9.47.1 NOTICES AND INFORMATION
+
+
+%% @sentry-internal/replay-canvas@9.47.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (c) 2024 Functional Software, Inc. dba Sentry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF @sentry-internal/replay-canvas@9.47.1 NOTICES AND INFORMATION
 
 
 %% @sentry/integrations@7.114.0 NOTICES AND INFORMATION BEGIN HERE
@@ -15201,11 +14925,11 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 END OF @sentry/utils@7.114.0 NOTICES AND INFORMATION
 
 
-%% ua-parser-js@1.0.39 NOTICES AND INFORMATION BEGIN HERE
+%% ua-parser-js@1.0.41 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
-Copyright (c) 2012-2024 Faisal Salman <<f@faisalman.com>>
+Copyright (c) 2012-2025 Faisal Salman <<f@faisalman.com>>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -15226,7 +14950,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF ua-parser-js@1.0.39 NOTICES AND INFORMATION
+END OF ua-parser-js@1.0.41 NOTICES AND INFORMATION
 
 
 %% inherits-browser@0.1.0 NOTICES AND INFORMATION BEGIN HERE
@@ -15278,22 +15002,8 @@ THE SOFTWARE.
 END OF object-refs@0.4.0 NOTICES AND INFORMATION
 
 
-%% mixpanel-browser@2.55.1 NOTICES AND INFORMATION BEGIN HERE
+%% mixpanel-browser@2.78.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
-Copyright 2015 Mixpanel, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this work except in compliance with the License.
-You may obtain a copy of the License below, or at:
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -15482,7 +15192,7 @@ limitations under the License.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2015 Mixpanel, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15497,7 +15207,7 @@ limitations under the License.
    limitations under the License.
 
 ==========================================
-END OF mixpanel-browser@2.55.1 NOTICES AND INFORMATION
+END OF mixpanel-browser@2.78.0 NOTICES AND INFORMATION
 
 
 %% p-defer@4.0.1 NOTICES AND INFORMATION BEGIN HERE
@@ -15593,7 +15303,7 @@ THE SOFTWARE.
 END OF @bpmn-io/replace-ids@0.2.0 NOTICES AND INFORMATION
 
 
-%% bpmnlint@11.6.0 NOTICES AND INFORMATION BEGIN HERE
+%% bpmnlint@11.12.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -15617,10 +15327,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF bpmnlint@11.6.0 NOTICES AND INFORMATION
+END OF bpmnlint@11.12.0 NOTICES AND INFORMATION
 
 
-%% bpmnlint-plugin-camunda-compat@2.39.2 NOTICES AND INFORMATION BEGIN HERE
+%% bpmnlint-plugin-camunda-compat@2.48.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -15644,7 +15354,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF bpmnlint-plugin-camunda-compat@2.39.2 NOTICES AND INFORMATION
+END OF bpmnlint-plugin-camunda-compat@2.48.1 NOTICES AND INFORMATION
 
 
 %% bpmnlint-utils@1.1.1 NOTICES AND INFORMATION BEGIN HERE
@@ -15674,7 +15384,7 @@ THE SOFTWARE.
 END OF bpmnlint-utils@1.1.1 NOTICES AND INFORMATION
 
 
-%% @bpmn-io/moddle-utils@0.2.1 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/moddle-utils@0.3.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -15698,7 +15408,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ==========================================
-END OF @bpmn-io/moddle-utils@0.2.1 NOTICES AND INFORMATION
+END OF @bpmn-io/moddle-utils@0.3.0 NOTICES AND INFORMATION
 
 
 %% semver-compare@1.0.0 NOTICES AND INFORMATION BEGIN HERE
@@ -15751,6 +15461,34 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
 END OF modeler-moddle@0.2.0 NOTICES AND INFORMATION
+
+
+%% lezer-feel@1.9.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (C) 2020 by Nico Rehwaldt <git_nikku@nixis.de> and others
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF lezer-feel@1.9.0 NOTICES AND INFORMATION
 
 
 %% htm@3.1.1 NOTICES AND INFORMATION BEGIN HERE
@@ -16169,7 +15907,7 @@ END OF htm@3.1.1 NOTICES AND INFORMATION
 END OF htm_preact@undefined NOTICES AND INFORMATION
 
 
-%% @codemirror/search@6.5.6 NOTICES AND INFORMATION BEGIN HERE
+%% @codemirror/search@6.6.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -16194,14 +15932,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF @codemirror/search@6.5.6 NOTICES AND INFORMATION
+END OF @codemirror/search@6.6.0 NOTICES AND INFORMATION
 
 
-%% codemirror@6.0.1 NOTICES AND INFORMATION BEGIN HERE
+%% codemirror@6.0.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
-Copyright (C) 2018-2021 by Marijn Haverbeke <marijnh@gmail.com> and others
+Copyright (C) 2018-2021 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -16222,10 +15960,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF codemirror@6.0.1 NOTICES AND INFORMATION
+END OF codemirror@6.0.2 NOTICES AND INFORMATION
 
 
-%% didi@10.2.2 NOTICES AND INFORMATION BEGIN HERE
+%% didi@11.0.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License
 
@@ -16250,7 +15988,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF didi@10.2.2 NOTICES AND INFORMATION
+END OF didi@11.0.0 NOTICES AND INFORMATION
 
 
 %% fast-xml-builder@1.1.4 NOTICES AND INFORMATION BEGIN HERE
@@ -16281,7 +16019,7 @@ SOFTWARE.
 END OF fast-xml-builder@1.1.4 NOTICES AND INFORMATION
 
 
-%% fast-xml-parser@5.5.6 NOTICES AND INFORMATION BEGIN HERE
+%% fast-xml-parser@5.5.11 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -16306,10 +16044,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF fast-xml-parser@5.5.6 NOTICES AND INFORMATION
+END OF fast-xml-parser@5.5.11 NOTICES AND INFORMATION
 
 
-%% path-expression-matcher@1.1.3 NOTICES AND INFORMATION BEGIN HERE
+%% path-expression-matcher@1.5.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -16334,10 +16072,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF path-expression-matcher@1.1.3 NOTICES AND INFORMATION
+END OF path-expression-matcher@1.5.0 NOTICES AND INFORMATION
 
 
-%% strnum@2.2.0 NOTICES AND INFORMATION BEGIN HERE
+%% strnum@2.2.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -16362,7 +16100,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF strnum@2.2.0 NOTICES AND INFORMATION
+END OF strnum@2.2.3 NOTICES AND INFORMATION
 
 
 %% @bpmn-io/add-exporter@0.2.0 NOTICES AND INFORMATION BEGIN HERE
@@ -16392,7 +16130,7 @@ THE SOFTWARE.
 END OF @bpmn-io/add-exporter@0.2.0 NOTICES AND INFORMATION
 
 
-%% @bpmn-io/variable-resolver@1.3.3 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/variable-resolver@3.0.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -16416,27 +16154,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF @bpmn-io/variable-resolver@1.3.3 NOTICES AND INFORMATION
+END OF @bpmn-io/variable-resolver@3.0.0 NOTICES AND INFORMATION
 
 
-%% domify@2.0.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-MIT License
-
-Copyright (c) TJ Holowaychuk <tj@tjholowaychuk.com>
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-==========================================
-END OF domify@2.0.0 NOTICES AND INFORMATION
-
-
-%% bpmn-js-color-picker@0.7.1 NOTICES AND INFORMATION BEGIN HERE
+%% bpmn-js-color-picker@0.7.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -16461,10 +16182,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF bpmn-js-color-picker@0.7.1 NOTICES AND INFORMATION
+END OF bpmn-js-color-picker@0.7.2 NOTICES AND INFORMATION
 
 
-%% bpmn-js-create-append-anything@0.6.0 NOTICES AND INFORMATION BEGIN HERE
+%% bpmn-js-create-append-anything@1.2.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -16488,10 +16209,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF bpmn-js-create-append-anything@0.6.0 NOTICES AND INFORMATION
+END OF bpmn-js-create-append-anything@1.2.0 NOTICES AND INFORMATION
 
 
-%% bpmn-js-element-templates@2.5.3 NOTICES AND INFORMATION BEGIN HERE
+%% bpmn-js-element-templates@2.23.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -16515,10 +16236,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF bpmn-js-element-templates@2.5.3 NOTICES AND INFORMATION
+END OF bpmn-js-element-templates@2.23.0 NOTICES AND INFORMATION
 
 
-%% semver@7.6.3 NOTICES AND INFORMATION BEGIN HERE
+%% semver@7.7.4 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The ISC License
 
@@ -16537,7 +16258,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ==========================================
-END OF semver@7.6.3 NOTICES AND INFORMATION
+END OF semver@7.7.4 NOTICES AND INFORMATION
 
 
 %% bpmn-js-executable-fix@0.2.1 NOTICES AND INFORMATION BEGIN HERE
@@ -16568,6 +16289,33 @@ SOFTWARE.
 END OF bpmn-js-executable-fix@0.2.1 NOTICES AND INFORMATION
 
 
+%% bpmn-js-native-copy-paste@0.3.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2020-present Nico Rehwaldt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF bpmn-js-native-copy-paste@0.3.0 NOTICES AND INFORMATION
+
+
 %% bpmn-js-tracking@0.6.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
@@ -16595,62 +16343,7 @@ THE SOFTWARE.
 END OF bpmn-js-tracking@0.6.0 NOTICES AND INFORMATION
 
 
-%% diagram-js-direct-editing@3.2.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-The MIT License (MIT)
-
-Copyright (c) 2014-2017 camunda Services GmbH
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-==========================================
-END OF diagram-js-direct-editing@3.2.0 NOTICES AND INFORMATION
-
-
-%% tiny-svg@3.1.2 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-The MIT License (MIT)
-
-Copyright (c) 2014 Nico Rehwaldt
-Copyright (c) 2015-present camunda Services GmbH
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-==========================================
-END OF tiny-svg@3.1.2 NOTICES AND INFORMATION
-
-
-%% camunda-bpmn-js-behaviors@1.9.1 NOTICES AND INFORMATION BEGIN HERE
+%% camunda-bpmn-js-behaviors@1.14.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -16674,10 +16367,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF camunda-bpmn-js-behaviors@1.9.1 NOTICES AND INFORMATION
+END OF camunda-bpmn-js-behaviors@1.14.1 NOTICES AND INFORMATION
 
 
-%% diagram-js-minimap@5.2.0 NOTICES AND INFORMATION BEGIN HERE
+%% diagram-js-minimap@5.3.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -16701,7 +16394,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF diagram-js-minimap@5.2.0 NOTICES AND INFORMATION
+END OF diagram-js-minimap@5.3.0 NOTICES AND INFORMATION
 
 
 %% @bpmn-io/align-to-origin@0.7.0 NOTICES AND INFORMATION BEGIN HERE
@@ -16731,7 +16424,7 @@ THE SOFTWARE.
 END OF @bpmn-io/align-to-origin@0.7.0 NOTICES AND INFORMATION
 
 
-%% @camunda/improved-canvas@1.7.6 NOTICES AND INFORMATION BEGIN HERE
+%% @camunda/improved-canvas@1.8.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -16755,7 +16448,117 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF @camunda/improved-canvas@1.7.6 NOTICES AND INFORMATION
+END OF @camunda/improved-canvas@1.8.0 NOTICES AND INFORMATION
+
+
+%% diagram-js-direct-editing@3.3.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014-2017 camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF diagram-js-direct-editing@3.3.0 NOTICES AND INFORMATION
+
+
+%% diagram-js-origin@1.4.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014  Nico Rehwaldt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF diagram-js-origin@1.4.0 NOTICES AND INFORMATION
+
+
+%% tiny-svg@3.1.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2014 Nico Rehwaldt
+Copyright (c) 2015-present camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF tiny-svg@3.1.3 NOTICES AND INFORMATION
+
+
+%% performance-now@2.1.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright (c) 2013 Braveg1rl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+==========================================
+END OF performance-now@2.1.0 NOTICES AND INFORMATION
+
+
+%% raf@3.4.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright 2013 Chris Dickinson <chris@neversaw.us>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+==========================================
+END OF raf@3.4.1 NOTICES AND INFORMATION
 
 
 %% rgbcolor@1.0.1 NOTICES AND INFORMATION BEGIN HERE
@@ -16791,89 +16594,7 @@ Please either apply this, the MIT license, or the license in './FEEL-FREE.md'
 END OF rgbcolor@1.0.1 NOTICES AND INFORMATION
 
 
-%% diagram-js-grid@1.1.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-The MIT License (MIT)
-
-Copyright (c) 2023-present camunda Services GmbH
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-==========================================
-END OF diagram-js-grid@1.1.0 NOTICES AND INFORMATION
-
-
-%% diagram-js-origin@1.4.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-The MIT License (MIT)
-
-Copyright (c) 2014  Nico Rehwaldt
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-==========================================
-END OF diagram-js-origin@1.4.0 NOTICES AND INFORMATION
-
-
-%% performance-now@2.1.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-Copyright (c) 2013 Braveg1rl
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-==========================================
-END OF performance-now@2.1.0 NOTICES AND INFORMATION
-
-
-%% raf@3.4.1 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-Copyright 2013 Chris Dickinson <chris@neversaw.us>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-==========================================
-END OF raf@3.4.1 NOTICES AND INFORMATION
-
-
-%% stackblur-canvas@2.5.0 NOTICES AND INFORMATION BEGIN HERE
+%% stackblur-canvas@2.7.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2010 Mario Klingemann
 
@@ -16899,7 +16620,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF stackblur-canvas@2.5.0 NOTICES AND INFORMATION
+END OF stackblur-canvas@2.7.0 NOTICES AND INFORMATION
 
 
 %% @bpmn-io/dmn-migrate@0.5.0 NOTICES AND INFORMATION BEGIN HERE
@@ -17011,14 +16732,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 END OF css.escape@1.5.1 NOTICES AND INFORMATION
 
 
-%% dmn-js-boxed-expression@17.1.0 NOTICES AND INFORMATION BEGIN HERE
+%% dmn-js-boxed-expression@17.7.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 null
 ==========================================
-END OF dmn-js-boxed-expression@17.1.0 NOTICES AND INFORMATION
+END OF dmn-js-boxed-expression@17.7.0 NOTICES AND INFORMATION
 
 
-%% dmn-js-decision-table@17.1.0 NOTICES AND INFORMATION BEGIN HERE
+%% dmn-js-decision-table@17.7.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2014-present Camunda Services GmbH
 
@@ -17044,10 +16765,10 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRA
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 OR OTHER DEALINGS IN THE SOFTWARE.
 ==========================================
-END OF dmn-js-decision-table@17.1.0 NOTICES AND INFORMATION
+END OF dmn-js-decision-table@17.7.0 NOTICES AND INFORMATION
 
 
-%% dmn-js-drd@17.1.0 NOTICES AND INFORMATION BEGIN HERE
+%% dmn-js-drd@17.7.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2014-present Camunda Services GmbH
 
@@ -17073,10 +16794,10 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRA
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 OR OTHER DEALINGS IN THE SOFTWARE.
 ==========================================
-END OF dmn-js-drd@17.1.0 NOTICES AND INFORMATION
+END OF dmn-js-drd@17.7.0 NOTICES AND INFORMATION
 
 
-%% dmn-js-literal-expression@17.1.0 NOTICES AND INFORMATION BEGIN HERE
+%% dmn-js-literal-expression@17.7.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2014-present Camunda Services GmbH
 
@@ -17102,10 +16823,10 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRA
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 OR OTHER DEALINGS IN THE SOFTWARE.
 ==========================================
-END OF dmn-js-literal-expression@17.1.0 NOTICES AND INFORMATION
+END OF dmn-js-literal-expression@17.7.0 NOTICES AND INFORMATION
 
 
-%% dmn-js-shared@17.1.0 NOTICES AND INFORMATION BEGIN HERE
+%% dmn-js-shared@17.7.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2014-present Camunda Services GmbH
 
@@ -17131,10 +16852,10 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRA
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 OR OTHER DEALINGS IN THE SOFTWARE.
 ==========================================
-END OF dmn-js-shared@17.1.0 NOTICES AND INFORMATION
+END OF dmn-js-shared@17.7.0 NOTICES AND INFORMATION
 
 
-%% dmn-js@17.1.0 NOTICES AND INFORMATION BEGIN HERE
+%% dmn-js@17.7.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2014-present Camunda Services GmbH
 
@@ -17160,7 +16881,7 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRA
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 OR OTHER DEALINGS IN THE SOFTWARE.
 ==========================================
-END OF dmn-js@17.1.0 NOTICES AND INFORMATION
+END OF dmn-js@17.7.0 NOTICES AND INFORMATION
 
 
 %% escape-html@1.0.3 NOTICES AND INFORMATION BEGIN HERE
@@ -17221,60 +16942,7 @@ THE SOFTWARE.
 END OF inferno@5.6.3 NOTICES AND INFORMATION
 
 
-%% selection-ranges@3.0.3 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-Copyright (c) 2017-present Nico Rehwaldt
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-==========================================
-END OF selection-ranges@3.0.3 NOTICES AND INFORMATION
-
-
-%% selection-update@0.1.2 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-The MIT License (MIT)
-
-Copyright (c) 2015 Nico Rehwaldt
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-==========================================
-END OF selection-update@0.1.2 NOTICES AND INFORMATION
-
-
-%% table-js@9.2.0 NOTICES AND INFORMATION BEGIN HERE
+%% table-js@9.4.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -17298,10 +16966,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF table-js@9.2.0 NOTICES AND INFORMATION
+END OF table-js@9.4.0 NOTICES AND INFORMATION
 
 
-%% @bpmn-io/form-js-editor@1.14.0 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/form-js-editor@1.21.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2021-present Camunda Services GmbH
 
@@ -17327,10 +16995,10 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRA
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 OR OTHER DEALINGS IN THE SOFTWARE.
 ==========================================
-END OF @bpmn-io/form-js-editor@1.14.0 NOTICES AND INFORMATION
+END OF @bpmn-io/form-js-editor@1.21.2 NOTICES AND INFORMATION
 
 
-%% @bpmn-io/form-js-playground@1.14.0 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/form-js-playground@1.21.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2021-present Camunda Services GmbH
 
@@ -17356,10 +17024,10 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRA
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 OR OTHER DEALINGS IN THE SOFTWARE.
 ==========================================
-END OF @bpmn-io/form-js-playground@1.14.0 NOTICES AND INFORMATION
+END OF @bpmn-io/form-js-playground@1.21.2 NOTICES AND INFORMATION
 
 
-%% @bpmn-io/form-js-viewer@1.14.0 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/form-js-viewer@1.21.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright (c) 2021-present Camunda Services GmbH
 
@@ -17385,7 +17053,7 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRA
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 OR OTHER DEALINGS IN THE SOFTWARE.
 ==========================================
-END OF @bpmn-io/form-js-viewer@1.14.0 NOTICES AND INFORMATION
+END OF @bpmn-io/form-js-viewer@1.21.2 NOTICES AND INFORMATION
 
 
 %% downloadjs@1.4.7 NOTICES AND INFORMATION BEGIN HERE
@@ -17416,33 +17084,6 @@ SOFTWARE.
 END OF downloadjs@1.4.7 NOTICES AND INFORMATION
 
 
-%% file-drops@0.5.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-The MIT License (MIT)
-
-Copyright (c) 2018-present Nico Rehwaldt
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-==========================================
-END OF file-drops@0.5.0 NOTICES AND INFORMATION
-
-
 %% flatpickr@4.6.13 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
@@ -17471,7 +17112,7 @@ SOFTWARE.
 END OF flatpickr@4.6.13 NOTICES AND INFORMATION
 
 
-%% lodash@4.17.21 NOTICES AND INFORMATION BEGIN HERE
+%% lodash@4.18.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
 
@@ -17522,7 +17163,7 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ==========================================
-END OF lodash@4.17.21 NOTICES AND INFORMATION
+END OF lodash@4.18.1 NOTICES AND INFORMATION
 
 
 %% @codemirror/lang-xml@6.1.0 NOTICES AND INFORMATION BEGIN HERE
@@ -17553,11 +17194,11 @@ THE SOFTWARE.
 END OF @codemirror/lang-xml@6.1.0 NOTICES AND INFORMATION
 
 
-%% @lezer/xml@1.0.1 NOTICES AND INFORMATION BEGIN HERE
+%% @lezer/xml@1.0.6 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
-Copyright (C) 2018 by Marijn Haverbeke <marijnh@gmail.com> and others
+Copyright (C) 2018 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -17578,7 +17219,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==========================================
-END OF @lezer/xml@1.0.1 NOTICES AND INFORMATION
+END OF @lezer/xml@1.0.6 NOTICES AND INFORMATION
 
 
 %% canvg@4.0.3 NOTICES AND INFORMATION BEGIN HERE
@@ -17609,7 +17250,7 @@ SOFTWARE.
 END OF canvg@4.0.3 NOTICES AND INFORMATION
 
 
-%% clsx@2.1.0 NOTICES AND INFORMATION BEGIN HERE
+%% clsx@2.1.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -17622,10 +17263,37 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF clsx@2.1.0 NOTICES AND INFORMATION
+END OF clsx@2.1.1 NOTICES AND INFORMATION
 
 
-%% path-intersection@3.0.0 NOTICES AND INFORMATION BEGIN HERE
+%% diagram-js-grid@2.0.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2023-present camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF diagram-js-grid@2.0.1 NOTICES AND INFORMATION
+
+
+%% path-intersection@4.1.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -17649,7 +17317,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ==========================================
-END OF path-intersection@3.0.0 NOTICES AND INFORMATION
+END OF path-intersection@4.1.0 NOTICES AND INFORMATION
 
 
 %% svg-pathdata@6.0.3 NOTICES AND INFORMATION BEGIN HERE
@@ -17679,6 +17347,59 @@ THE SOFTWARE.
 END OF svg-pathdata@6.0.3 NOTICES AND INFORMATION
 
 
+%% selection-update@1.1.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2015 Nico Rehwaldt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF selection-update@1.1.1 NOTICES AND INFORMATION
+
+
+%% selection-ranges@4.1.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+Copyright (c) 2017-present Nico Rehwaldt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF selection-ranges@4.1.1 NOTICES AND INFORMATION
+
+
 %% zeebe-dmn-moddle@1.0.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
@@ -17706,7 +17427,7 @@ THE SOFTWARE.
 END OF zeebe-dmn-moddle@1.0.0 NOTICES AND INFORMATION
 
 
-%% @bpmn-io/element-templates-validator@2.3.3 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/element-templates-validator@2.20.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 MIT License
 
@@ -17731,10 +17452,72 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==========================================
-END OF @bpmn-io/element-templates-validator@2.3.3 NOTICES AND INFORMATION
+END OF @bpmn-io/element-templates-validator@2.20.1 NOTICES AND INFORMATION
 
 
-%% uuid@11.0.3 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/feel-analyzer@0.1.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2026 Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+==========================================
+END OF @bpmn-io/feel-analyzer@0.1.0 NOTICES AND INFORMATION
+
+
+%% @bpmn-io/svg-to-image@1.0.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2026-present Camunda Services GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF @bpmn-io/svg-to-image@1.0.1 NOTICES AND INFORMATION
+
+
+%% bpmn-js-copy-as-image@0.4.1 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+null
+==========================================
+END OF bpmn-js-copy-as-image@0.4.1 NOTICES AND INFORMATION
+
+
+%% uuid@13.0.0 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -17747,10 +17530,10 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF uuid@11.0.3 NOTICES AND INFORMATION
+END OF uuid@13.0.0 NOTICES AND INFORMATION
 
 
-%% @bpmn-io/draggle@4.1.1 NOTICES AND INFORMATION BEGIN HERE
+%% @bpmn-io/draggle@4.1.2 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 
@@ -17775,15 +17558,70 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ==========================================
-END OF @bpmn-io/draggle@4.1.1 NOTICES AND INFORMATION
+END OF @bpmn-io/draggle@4.1.2 NOTICES AND INFORMATION
 
 
-%% big.js@6.2.2 NOTICES AND INFORMATION BEGIN HERE
+%% @codemirror/lang-json@6.0.2 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (C) 2018-2021 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==========================================
+END OF @codemirror/lang-json@6.0.2 NOTICES AND INFORMATION
+
+
+%% @lezer/json@1.0.3 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+MIT License
+
+Copyright (C) 2020 by Marijn Haverbeke <marijn@haverbeke.berlin>, Arun Srinivasan <rulfzid@gmail.com>, and others
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF @lezer/json@1.0.3 NOTICES AND INFORMATION
+
+
+%% big.js@7.0.1 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 The MIT License (MIT)
 =====================
 
-Copyright © `<2024>` `Michael Mclaughlin`
+Copyright © `<2025>` `Michael Mclaughlin`
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
@@ -17808,65 +17646,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 
 ==========================================
-END OF big.js@6.2.2 NOTICES AND INFORMATION
+END OF big.js@7.0.1 NOTICES AND INFORMATION
 
 
-%% @codemirror/lang-json@6.0.1 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-MIT License
-
-Copyright (C) 2018-2021 by Marijn Haverbeke <marijnh@gmail.com> and others
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-==========================================
-END OF @codemirror/lang-json@6.0.1 NOTICES AND INFORMATION
-
-
-%% @lezer/json@1.0.0 NOTICES AND INFORMATION BEGIN HERE
-==========================================
-MIT License
-
-Copyright (C) 2020 by Marijn Haverbeke <marijnh@gmail.com>, Arun Srinivasan <rulfzid@gmail.com>, and others
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-==========================================
-END OF @lezer/json@1.0.0 NOTICES AND INFORMATION
-
-
-%% dompurify@3.2.4 NOTICES AND INFORMATION BEGIN HERE
+%% dompurify@3.3.3 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 DOMPurify
 Copyright 2025 Dr.-Ing. Mario Heiderich, Cure53
@@ -18438,10 +18221,37 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
 
 
 ==========================================
-END OF dompurify@3.2.4 NOTICES AND INFORMATION
+END OF dompurify@3.3.3 NOTICES AND INFORMATION
 
 
-%% marked@15.0.7 NOTICES AND INFORMATION BEGIN HERE
+%% file-drops@0.7.0 NOTICES AND INFORMATION BEGIN HERE
+==========================================
+The MIT License (MIT)
+
+Copyright (c) 2018-present Nico Rehwaldt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==========================================
+END OF file-drops@0.7.0 NOTICES AND INFORMATION
+
+
+%% marked@17.0.6 NOTICES AND INFORMATION BEGIN HERE
 ==========================================
 # License information
 
@@ -18489,7 +18299,7 @@ Redistribution and use in source and binary forms, with or without modification,
 This software is provided by the copyright holders and contributors “as is” and any express or implied warranties, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose are disclaimed. In no event shall the copyright owner or contributors be liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including, but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the use of this software, even if advised of the possibility of such damage.
 
 ==========================================
-END OF marked@15.0.7 NOTICES AND INFORMATION
+END OF marked@17.0.6 NOTICES AND INFORMATION
 
 
 %% vscode-windows-ca-certs@0.3.0 NOTICES AND INFORMATION BEGIN HERE

--- a/client/src/app/__tests__/TabsProviderSpec.js
+++ b/client/src/app/__tests__/TabsProviderSpec.js
@@ -253,7 +253,7 @@ describe('TabsProvider', function() {
         const { file: { contents } } = tabsProvider.createTab('bpmn');
 
         // then
-        expect(contents).to.include('modeler:executionPlatformVersion="2.0.0"');
+        expect(contents).to.include('modeler:executionPlatformVersion="3.0.0"');
       });
 
 
@@ -269,7 +269,7 @@ describe('TabsProvider', function() {
         const { file: { contents } } = tabsProvider.createTab('dmn');
 
         // then
-        expect(contents).to.include('modeler:executionPlatformVersion="2.0.0"');
+        expect(contents).to.include('modeler:executionPlatformVersion="3.0.0"');
       });
 
 
@@ -285,7 +285,7 @@ describe('TabsProvider', function() {
         const { file: { contents } } = tabsProvider.createTab('form');
 
         // then
-        expect(contents).to.include('"executionPlatformVersion": "2.0.0"');
+        expect(contents).to.include('"executionPlatformVersion": "3.0.0"');
       });
 
       describe('invalid flag', function() {

--- a/client/src/util/Engines.js
+++ b/client/src/util/Engines.js
@@ -27,8 +27,8 @@ export const ENGINE_PROFILES = [
   },
   {
     executionPlatform: ENGINES.FLUXNOVA,
-    executionPlatformVersions: [ '1.0.0' ,'2.0.0' ],
-    latestStable: '2.0.0'
+    executionPlatformVersions: [ '1.0.0', '2.0.0', '3.0.0' ],
+    latestStable: '3.0.0'
   }
 ];
 

--- a/client/src/util/__tests__/EnginesSpec.js
+++ b/client/src/util/__tests__/EnginesSpec.js
@@ -29,7 +29,7 @@ describe('util/Engines', function() {
 
     it('Camunda Platform', verifyLatestStable(ENGINES.PLATFORM, '7.22.0'));
 
-    it('Fluxnova Platform', verifyLatestStable(ENGINES.FLUXNOVA, '2.0.0'));
+    it('Fluxnova Platform', verifyLatestStable(ENGINES.FLUXNOVA, '3.0.0'));
 
     it('Camunda Cloud', verifyLatestStable(ENGINES.CLOUD, '8.6.0'));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -204,31 +204,6 @@
         }
       }
     },
-    "client/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "client/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
     "client/node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -263,15 +238,6 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      }
-    },
-    "client/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -8473,37 +8439,30 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -8519,9 +8478,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@puppeteer/browsers": {
@@ -30888,24 +30847,23 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -31231,7 +31189,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -31244,7 +31201,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -31252,13 +31208,6 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
-    },
-    "node_modules/react-dom/node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
@@ -33856,6 +33805,15 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {


### PR DESCRIPTION
In this PR below changes have been made:

protobufjs is upgraded to latest 7.x.x
Update THIRD_PARTY_NOTICES
Update CHANGELOG.md
Bump engine version to 3.0.0

closes #102 