### PR TITLE
Add support for restricted variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the [Fluxnova Modeler](https://github.com/finos/fluxnova-
 
 **\_Note:** Yet to be released changes appear here.\_
 
+## 1.3.0
+
+- Add support for restricted variables
+
 ## 1.2.0
 
 - Added retry time cycle functionality for element templates

--- a/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
+++ b/client/src/app/tabs/bpmn/modeler/BpmnModeler.js
@@ -18,6 +18,8 @@ import handToolOnSpaceModule from './features/hand-tool-on-space';
 import propertiesPanelKeyboardBindingsModule from './features/properties-panel-keyboard-bindings';
 import propPanelExtensionModule from './features/properties-panel-extension';
 import bpmnFormExtensionProviderModule from './features/properties-panel-form-group';
+import restrictedIoModule from './features/restricted-io';
+
 import lintingAnnotationsModule from '@camunda/linting/modeler';
 
 import { BpmnJSTracking as bpmnJSTracking } from 'bpmn-js-tracking';
@@ -79,6 +81,7 @@ const extensionModules = [
   propertiesPanelKeyboardBindingsModule,
   bpmnFormExtensionProviderModule,
   propPanelExtensionModule,
+  restrictedIoModule,
   lintingAnnotationsModule,
   bpmnJSTracking,
   contextPadTracking,

--- a/client/src/app/tabs/bpmn/modeler/features/restricted-io/RestrictedIOPlugin.js
+++ b/client/src/app/tabs/bpmn/modeler/features/restricted-io/RestrictedIOPlugin.js
@@ -1,0 +1,176 @@
+import {
+  CheckboxEntry as DefaultCheckboxEntry,
+  isCheckboxEntryEdited
+} from '@bpmn-io/properties-panel';
+
+const SUPPORTED_RESTRICTED_TYPES = new Set([
+  'camunda:InputParameter',
+  'camunda:OutputParameter',
+  'camunda:In',
+  'camunda:Out'
+]);
+
+export default class RestrictedIOPlugin {
+  constructor(propertiesPanel, commandStack, CheckboxEntry = DefaultCheckboxEntry) {
+    this.commandStack = commandStack;
+    this.CheckboxEntry = CheckboxEntry;
+    propertiesPanel.registerProvider(100, this);
+  }
+
+  getGroups(element) {
+
+    return (groups) => {
+      const { inputOutput, inOutMappings } = this.getRestrictedCandidates(element);
+      const inputParams = (inputOutput && inputOutput.inputParameters) || [];
+      const outputParams = (inputOutput && inputOutput.outputParameters) || [];
+
+      groups
+        .filter(g => g.id && g.id.startsWith('CamundaPlatform__'))
+        .forEach(group => {
+          (group.items || []).forEach(item => {
+            if (!Array.isArray(item.entries)) {
+              return;
+            }
+
+            const parameter = this.getParameterForItem(item, {
+              inputParams,
+              outputParams,
+              inOutMappings,
+              groupId: group.id
+            });
+
+            if (!parameter || !SUPPORTED_RESTRICTED_TYPES.has(parameter.$type)) {
+              return;
+            }
+
+            this.insertRestrictedEntry(item, parameter);
+          });
+        });
+
+      return groups;
+    };
+  }
+
+  getRestrictedCandidates(element) {
+    const bo = element.businessObject;
+    const ext = bo.extensionElements;
+
+    if (!ext || !Array.isArray(ext.values)) {
+      return {
+        inputOutput: null,
+        inOutMappings: []
+      };
+    }
+
+    return {
+      inputOutput: ext.values.find(v => v.$type === 'camunda:InputOutput') || null,
+      inOutMappings: ext.values.filter(v => v.$type === 'camunda:In' || v.$type === 'camunda:Out')
+    };
+  }
+
+  getParameterForItem(item, { inputParams, outputParams, inOutMappings, groupId }) {
+    if (groupId === 'CamundaPlatform__In' || groupId === 'CamundaPlatform__Out') {
+      const anyMappingEntry = item.entries.find(e => e && e.mapping);
+      if (anyMappingEntry) return anyMappingEntry.mapping;
+      return inOutMappings.find(m => m.id && m.id === item.id) || null;
+    }
+
+    const entryParameter = this.getParameterFromEntries(item.entries);
+
+    if (entryParameter) {
+      return entryParameter;
+    }
+
+    if (groupId === 'CamundaPlatform__Input' || groupId === 'CamundaPlatform__Output') {
+      const paramName = item.label || item.id;
+
+      return (
+        inputParams.find(p => p.name === paramName) ||
+        outputParams.find(p => p.name === paramName) ||
+        null
+      );
+    }
+
+    return inOutMappings.find(mapping => mapping.id && mapping.id === item.id) || null;
+  }
+
+  getParameterFromEntries(entries) {
+    const localEntry = entries.find(e => e && e.id && e.id.endsWith('-local') && e.mapping);
+
+    if (localEntry && localEntry.mapping) {
+      return localEntry.mapping;
+    }
+
+    const parameterEntry = entries.find(e => e && (e.parameter || e.mapping));
+
+    if (!parameterEntry) {
+      return null;
+    }
+
+    return parameterEntry.parameter || parameterEntry.mapping;
+  }
+
+  insertRestrictedEntry(item, parameter) {
+    const restrictedEntryId = `restricted-${item.id}`;
+
+    const hasRestrictedEntry = item.entries.some(entry => entry && entry.id === restrictedEntryId);
+
+    if (hasRestrictedEntry) {
+      return;
+    }
+
+    const restrictedEntry = {
+      id: restrictedEntryId,
+      component: this.RestrictedCheckbox,
+      type: 'input',
+      parameter,
+      isEdited: isCheckboxEntryEdited
+    };
+
+    const localIndex = item.entries.findIndex(entry => entry && entry.id && entry.id.endsWith('-local'));
+
+    if (localIndex !== -1) {
+      item.entries.splice(localIndex + 1, 0, restrictedEntry);
+      return;
+    }
+
+    item.entries.push(restrictedEntry);
+  }
+
+  getInputOutput(element) {
+    const bo = element.businessObject;
+    const ext = bo.extensionElements;
+    if (!ext) return null;
+
+    return ext.values.find(v => v.$type === 'camunda:InputOutput');
+  }
+
+
+  RestrictedCheckbox = (props)=> {
+    const { element, parameter } = props;
+
+    return this.CheckboxEntry({
+      element,
+      id: 'restricted',
+      label: 'Restricted',
+      getValue: () => {
+        return !!parameter.get('restricted');
+      },
+      setValue: (value) => {
+        this.commandStack.execute('element.updateModdleProperties', {
+          element: element, // the task shape
+          moddleElement: parameter, // the actual parameter moddle element
+          properties: {
+            restricted: !!value
+          }
+        });
+      }
+    });
+  };
+}
+
+RestrictedIOPlugin.$inject = [
+  'propertiesPanel',
+  'commandStack'
+];
+

--- a/client/src/app/tabs/bpmn/modeler/features/restricted-io/__tests__/RestrictedIOPluginSpec.js
+++ b/client/src/app/tabs/bpmn/modeler/features/restricted-io/__tests__/RestrictedIOPluginSpec.js
@@ -1,0 +1,295 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import RestrictedIOPlugin from '../RestrictedIOPlugin';
+
+// Mock CheckboxEntry because it's a Preact component using hooks
+// which doesn't work in this simple unit test environment.
+const CheckboxEntryMock = sinon.stub().callsFake(props => ({ props }));
+
+describe('RestrictedIOPlugin', function() {
+  let propertiesPanelSpy, commandStack;
+
+  beforeEach(function() {
+    propertiesPanelSpy = { registerProvider: sinon.spy() };
+    commandStack = { execute: sinon.spy() };
+  });
+
+  afterEach(function() {
+    sinon.restore();
+  });
+
+  it('should register provider with propertiesPanel', function() {
+    new RestrictedIOPlugin(propertiesPanelSpy, commandStack);
+
+    expect(propertiesPanelSpy.registerProvider.calledOnce).to.be.true;
+    expect(propertiesPanelSpy.registerProvider.firstCall.args[0]).to.equal(100);
+  });
+
+  describe('#getGroups', function() {
+    let plugin, element;
+    let inMapping, outMapping;
+
+    beforeEach(function() {
+      plugin = new RestrictedIOPlugin(propertiesPanelSpy, commandStack, CheckboxEntryMock);
+
+      inMapping = {
+        id: 'in-map-1',
+        $type: 'camunda:In',
+        get: sinon.stub().withArgs('restricted').returns(false)
+      };
+
+      outMapping = {
+        id: 'out-map-1',
+        $type: 'camunda:Out',
+        get: sinon.stub().withArgs('restricted').returns(false)
+      };
+
+      // Mock element with camunda:InputOutput extension
+      element = {
+        businessObject: {
+          extensionElements: {
+            values: [
+              {
+                $type: 'camunda:InputOutput',
+                inputParameters: [
+                  {
+                    name: 'input1',
+                    $type: 'camunda:InputParameter',
+                    get: sinon.stub().returns(undefined)
+                  }
+                ],
+                outputParameters: [
+                  {
+                    name: 'output1',
+                    $type: 'camunda:OutputParameter',
+                    get: sinon.stub().returns(true)
+                  }
+                ],
+                get: sinon.stub()
+              },
+              inMapping,
+              outMapping
+            ]
+          }
+        }
+      };
+    });
+
+    it('should return a function that modifies groups', function() {
+      const groupModifier = plugin.getGroups(element);
+      expect(groupModifier).to.be.a('function');
+    });
+
+    it('should add restricted entries to Input/Output groups', function() {
+      const groups = [
+        {
+          id: 'CamundaPlatform__Input',
+          items: [
+            { id: 'input1', label: 'input1', entries: [] }
+          ]
+        },
+        {
+          id: 'CamundaPlatform__Output',
+          items: [
+            { id: 'output1', label: 'output1', entries: [] }
+          ]
+        }
+      ];
+
+      const groupModifier = plugin.getGroups(element);
+      const resultGroups = groupModifier(groups);
+
+      const inputItem = resultGroups.find(g => g.id === 'CamundaPlatform__Input').items[0];
+      const outputItem = resultGroups.find(g => g.id === 'CamundaPlatform__Output').items[0];
+
+      expect(inputItem.entries).to.have.lengthOf(1);
+      expect(inputItem.entries[0].id).to.equal('restricted-input1');
+      expect(outputItem.entries[0].id).to.equal('restricted-output1');
+    });
+
+    it('should insert restricted directly below Local for call activity In/Out mappings', function() {
+      const groups = [
+        {
+          id: 'CamundaPlatform__In',
+          items: [
+            {
+              id: 'in-map-1',
+              label: 'in-map-1',
+              entries: [
+                { id: 'in-map-1-source', parameter: inMapping },
+                { id: 'in-map-1-local', mapping: inMapping },
+                { id: 'in-map-1-target', parameter: inMapping }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'CamundaPlatform__Out',
+          items: [
+            {
+              id: 'out-map-1',
+              label: 'out-map-1',
+              entries: [
+                { id: 'out-map-1-source', parameter: outMapping },
+                { id: 'out-map-1-local', mapping: outMapping },
+                { id: 'out-map-1-target', parameter: outMapping }
+              ]
+            }
+          ]
+        }
+      ];
+
+      const resultGroups = plugin.getGroups(element)(groups);
+
+      const inEntries = resultGroups.find(g => g.id === 'CamundaPlatform__In').items[0].entries;
+      const outEntries = resultGroups.find(g => g.id === 'CamundaPlatform__Out').items[0].entries;
+
+      const inLocalIndex = inEntries.findIndex(e => e.id === 'in-map-1-local');
+      const outLocalIndex = outEntries.findIndex(e => e.id === 'out-map-1-local');
+
+      expect(inEntries[inLocalIndex + 1].id).to.equal('restricted-in-map-1');
+      expect(outEntries[outLocalIndex + 1].id).to.equal('restricted-out-map-1');
+    });
+
+    it('should still add restricted entry even when Local mapping is absent on call mappings', function() {
+      const groups = [
+        {
+          id: 'CamundaPlatform__In',
+          items: [
+            {
+              id: 'in-map-1',
+              label: 'in-map-1',
+              entries: [
+                { id: 'in-map-1-source', mapping: inMapping },
+                { id: 'in-map-1-target', mapping: inMapping }
+              ]
+            }
+          ]
+        }
+      ];
+
+      const resultGroups = plugin.getGroups(element)(groups);
+      const entries = resultGroups[0].items[0].entries;
+
+      expect(entries.some(e => e.id === 'restricted-in-map-1')).to.be.true;
+    });
+
+    it('should not duplicate restricted entries on repeated processing', function() {
+      const groups = [
+        {
+          id: 'CamundaPlatform__In',
+          items: [
+            {
+              id: 'in-map-1',
+              label: 'in-map-1',
+              entries: [
+                { id: 'in-map-1-source', parameter: inMapping },
+                { id: 'in-map-1-local', mapping: inMapping },
+                { id: 'in-map-1-target', parameter: inMapping }
+              ]
+            }
+          ]
+        }
+      ];
+
+      const groupModifier = plugin.getGroups(element);
+      groupModifier(groups);
+      groupModifier(groups);
+
+      const entries = groups[0].items[0].entries;
+      const restrictedEntries = entries.filter(e => e.id === 'restricted-in-map-1');
+
+      expect(restrictedEntries).to.have.lengthOf(1);
+    });
+
+    it('should not modify non-CamundaPlatform groups', function() {
+      const groups = [
+        {
+          id: 'ElementTemplates__Input',
+          items: [
+            {
+              id: 'templated-item',
+              entries: [
+                { id: 'templated-item-local', mapping: inMapping }
+              ]
+            }
+          ]
+        }
+      ];
+
+      const resultGroups = plugin.getGroups(element)(groups);
+      const entries = resultGroups[0].items[0].entries;
+
+      expect(entries.some(e => e.id === 'restricted-templated-item')).to.be.false;
+    });
+  });
+
+  describe('RestrictedCheckbox', function() {
+    let plugin;
+
+    beforeEach(function() {
+      plugin = new RestrictedIOPlugin(propertiesPanelSpy, commandStack, CheckboxEntryMock);
+      CheckboxEntryMock.resetHistory();
+    });
+
+    it('should get value from restricted property', function() {
+      const parameter = {
+        get: sinon.stub().withArgs('restricted').returns(true)
+      };
+
+      const props = { element: {}, parameter };
+      plugin.RestrictedCheckbox(props);
+
+      const checkboxProps = CheckboxEntryMock.firstCall.args[0];
+      const value = checkboxProps.getValue();
+      expect(value).to.be.true;
+    });
+
+    it('should return false when restricted property is false', function() {
+      const parameter = {
+        get: sinon.stub().withArgs('restricted').returns(false)
+      };
+
+      const props = { element: {}, parameter };
+      plugin.RestrictedCheckbox(props);
+
+      const checkboxProps = CheckboxEntryMock.firstCall.args[0];
+      const value = checkboxProps.getValue();
+      expect(value).to.be.false;
+    });
+
+    it('should execute command on setValue(true)', function() {
+      const element = { id: 'element1' };
+      const parameter = {
+        id: 'param1',
+        get: sinon.stub()
+      };
+      const props = { element, parameter };
+
+      plugin.RestrictedCheckbox(props);
+      const checkboxProps = CheckboxEntryMock.firstCall.args[0];
+      checkboxProps.setValue(true);
+
+      expect(commandStack.execute.calledOnce).to.be.true;
+      expect(commandStack.execute.firstCall.args[0]).to.equal('element.updateModdleProperties');
+      expect(commandStack.execute.firstCall.args[1].properties.restricted).to.be.true;
+      expect(commandStack.execute.firstCall.args[1].properties).to.not.have.property('restrictionTag');
+    });
+
+    it('should execute command with false on setValue(false)', function() {
+      const element = { id: 'element1' };
+      const parameter = {
+        id: 'param1',
+        get: sinon.stub()
+      };
+      const props = { element, parameter };
+
+      plugin.RestrictedCheckbox(props);
+      const checkboxProps = CheckboxEntryMock.firstCall.args[0];
+      checkboxProps.setValue(false);
+
+      expect(commandStack.execute.firstCall.args[1].properties.restricted).to.be.false;
+      expect(commandStack.execute.firstCall.args[1].properties).to.not.have.property('restrictionTag');
+    });
+  });
+});

--- a/client/src/app/tabs/bpmn/modeler/features/restricted-io/index.js
+++ b/client/src/app/tabs/bpmn/modeler/features/restricted-io/index.js
@@ -1,0 +1,10 @@
+import RestrictedIOPlugin from './RestrictedIOPlugin';
+import restrictedModdle from './restricted.json';
+
+export default {
+  __init__: [ 'RestrictedIOPlugin' ],
+  RestrictedIOPlugin: [ 'type', RestrictedIOPlugin ],
+  moddleExtensions: {
+    restricted: restrictedModdle
+  }
+};

--- a/client/src/app/tabs/bpmn/modeler/features/restricted-io/restricted.json
+++ b/client/src/app/tabs/bpmn/modeler/features/restricted-io/restricted.json
@@ -1,0 +1,49 @@
+{
+  "name": "RestrictedExtension",
+  "uri": "http://example.com/schema/restricted",
+  "prefix": "restricted",
+  "xml": {
+    "tagAlias": "lowerCase"
+  },
+  "types": [
+    {
+      "name": "RestrictedCapable",
+      "isAbstract": true,
+      "properties": [
+        {
+          "name": "restricted",
+          "type": "Boolean",
+          "isAttr": true
+        }
+      ]
+    },
+    {
+      "name": "InputParameter",
+      "extends": [
+        "camunda:InputParameter",
+        "RestrictedCapable"
+      ]
+    },
+    {
+      "name": "OutputParameter",
+      "extends": [
+        "camunda:OutputParameter",
+        "RestrictedCapable"
+      ]
+    },
+    {
+      "name": "In",
+      "extends": [
+        "camunda:In",
+        "RestrictedCapable"
+      ]
+    },
+    {
+      "name": "Out",
+      "extends": [
+        "camunda:Out",
+        "RestrictedCapable"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Proposed Changes

Introduce Restricted checkbox entry in input and output parameters in the BPMN properties panel to flag variables as restricted.

<img width="860" height="626" alt="608895854-8183c6f7-8c7d-4207-9fb3-7684eb4de2eb" src="https://github.com/user-attachments/assets/6ef1656b-ad13-430a-8afc-265d59c41fdb" />

related to https://github.com/finos/fluxnova-bpm-platform/issues/36
closes https://github.com/finos/fluxnova-modeler/issues/97