### PR TITLE
Fixed deep links to use correct Fluxnova Monitoring URL path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the [Fluxnova Modeler](https://github.com/finos/fluxnova-
 
 **\_Note:** Yet to be released changes appear here.\_
 
+## 1.3.1
+
+- Fixed deep links to use correct Fluxnova Monitoring URL path
+
 ## 1.3.0
 
 - Updated react, react-dom, react-test-renderer from 16.14.0 to 18.3.1

--- a/client/src/plugins/camunda-plugin/shared/__tests__/webAppUrlsSpec.js
+++ b/client/src/plugins/camunda-plugin/shared/__tests__/webAppUrlsSpec.js
@@ -32,13 +32,13 @@ describe('<webAppUrls>', function() {
     it('should return specific Cockpit link', async function() {
 
       // given
-      stubGetCockpitUrl().returns('http://localhost:18080/fluxnova/app/monitoring/default/#/');
+      stubGetCockpitUrl().returns('http://localhost:18080/fluxnova-monitoring/app/monitoring/default/#/');
 
       // when
       const cockpitUrl = await determineCockpitUrl('http://localhost:18080/fluxnova/rest');
 
       // then
-      expect(cockpitUrl).to.be.equal('http://localhost:18080/fluxnova/app/monitoring/default/#/');
+      expect(cockpitUrl).to.be.equal('http://localhost:18080/fluxnova-monitoring/app/monitoring/default/#/');
     });
 
 
@@ -98,7 +98,7 @@ describe('<webAppUrls>', function() {
       const cockpitUrl = await determineCockpitUrl(engineRestUrl);
 
       // then
-      expect(cockpitUrl).to.be.equal('http://localhost:8080/fluxnova/app/monitoring/default/#/');
+      expect(cockpitUrl).to.be.equal('http://localhost:8080/fluxnova-monitoring/app/monitoring/default/#/');
     });
 
 

--- a/client/src/plugins/camunda-plugin/shared/webAppUrls.js
+++ b/client/src/plugins/camunda-plugin/shared/webAppUrls.js
@@ -43,7 +43,7 @@ function getDefaultCockpitUrl(engineUrl) {
 function getDefaultWebAppsBaseUrl(engineUrl) {
   const [ protocol,, host, restRoot ] = engineUrl.split('/');
 
-  return isTomcat(restRoot) ? `${protocol}//${host}/fluxnova/app/` : `${protocol}//${host}/app/`;
+  return isTomcat(restRoot) ? `${protocol}//${host}/fluxnova-monitoring/app/` : `${protocol}//${host}/app/`;
 }
 
 function isTomcat(restRoot) {


### PR DESCRIPTION
### Proposed Changes

Generated deep links should use the correct monitoring URL path /fluxnova-monitoring/app/ instead of /fluxnova/app/. Users should be directed to the correct monitoring dashboard showing the deployed process definition or started process instance.

closes #108 