### PR TITLE
Fix for issue 88 - "Users cannot override Fluxnova engine version when creating bpmn

### DIFF
--- a/client/src/app/tabs/EngineProfile.js
+++ b/client/src/app/tabs/EngineProfile.js
@@ -9,24 +9,17 @@
  */
 
 import React, { useState, useRef } from 'react';
-
 import classnames from 'classnames';
-
 import semverCompare from 'semver-compare';
 
-
-import {
-  FLUXNOVA_ENGINE_VERSION
-} from '../../util/Flags';
-
+import { ENGINES, ENGINE_LABELS, ENGINE_PROFILES, getLatestStable } from '../../util/Engines';
+import Flags, { FLUXNOVA_ENGINE_VERSION } from '../../util/Flags';
 import {
   Overlay,
   Section
 } from '../../shared/ui';
 
 import { Fill } from '../slot-fill';
-
-import { ENGINES, ENGINE_LABELS, ENGINE_PROFILES, getLatestStable } from '../../util/Engines';
 
 const HELP_LINKS = {
   [ ENGINES.FLUXNOVA ]: 'https://docs.fluxnova.finos.org/',
@@ -304,7 +297,7 @@ export function getDefaultVersion(engine) {
 }
 
 function getFlagVersion() {
-  return FLUXNOVA_ENGINE_VERSION;
+  return Flags.get(FLUXNOVA_ENGINE_VERSION, null);
 }
 
 function getVersions(engine) {

--- a/client/src/app/tabs/__tests__/EngineProfileSpec.js
+++ b/client/src/app/tabs/__tests__/EngineProfileSpec.js
@@ -19,9 +19,11 @@ import {
   Slot
 } from '../../slot-fill';
 
-import { EngineProfile, getAnnotatedVersion, getStatusBarLabel, toSemverMinor } from '../EngineProfile';
+import { EngineProfile, getAnnotatedVersion, getDefaultVersion, getStatusBarLabel, toSemverMinor } from '../EngineProfile';
 
 import { ENGINES, ENGINE_PROFILES } from '../../../util/Engines';
+
+import Flags, { FLUXNOVA_ENGINE_VERSION } from '../../../util/Flags';
 
 import { DEFAULT_ENGINE_PROFILE as bpmnEngineProfile } from '../bpmn/BpmnEditor';
 import { DEFAULT_ENGINE_PROFILE as cloudBpmnEngineProfile } from '../cloud-bpmn/BpmnEditor';
@@ -195,6 +197,7 @@ describe('<EngineProfile>', function() {
 
   });
 
+
   describe('#getStatusBarLabel', function() {
 
     it('should return correct annotated versions', function() {
@@ -214,6 +217,38 @@ describe('<EngineProfile>', function() {
         })).to.equal(input[2]);
       });
 
+    });
+
+  });
+
+
+  describe('#getDefaultVersion', function() {
+
+    afterEach(function() {
+      Flags.reset();
+    });
+
+
+    it('should return flag version when <fluxnova-engine-version> is set', function() {
+
+      // given
+      Flags.init({ [FLUXNOVA_ENGINE_VERSION]: '1.0.0' });
+
+      // when
+      const result = getDefaultVersion(ENGINES.FLUXNOVA);
+
+      // then
+      expect(result).to.equal('1.0.0');
+    });
+
+
+    it('should return latest stable when <fluxnova-engine-version> is not set', function() {
+
+      // when
+      const result = getDefaultVersion(ENGINES.FLUXNOVA);
+
+      // then
+      expect(result).to.equal('3.0.0');
     });
 
   });
@@ -427,7 +462,6 @@ function renderEngineProfile(options = {}) {
   );
 }
 
-
 function eachProfile(fn) {
   ENGINE_PROFILES.forEach(({ executionPlatform, executionPlatformVersions }) => {
     [
@@ -467,3 +501,4 @@ function selectVersion(select, version) {
 function expectVersion(select, version) {
   expect(select.value).to.equal(version || '');
 }
+


### PR DESCRIPTION
### Proposed Changes

Closes [issue 88](https://github.com/finos/fluxnova-modeler/issues/88). Update to the EngineProfile to allow overwrite of engine version via Flag config.

Before:

<img width="1067" height="646" alt="image" src="https://github.com/user-attachments/assets/3805a10d-bd70-4f5b-86a2-d99c22c6c1b4" />

After:

<img width="1148" height="993" alt="image" src="https://github.com/user-attachments/assets/b8669bc6-a9f8-4105-ab3d-74f0b925db69" />

Steps to reproduce:
- Update flags.json with "fluxnova-engine-version": "1.0.0"
- Run the modeller
- Create a new BPMN file via File > New File > BPMN diagram
- Inspect the execution platform version set on the new model

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] __Brief textual description__ of the changes present
* [x] __Visual demo__ attached
* [x] __Steps to try out__ present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--
Thanks for creating this pull request! ❤️
-->
