### PR TITLE
Fix canvas copy paste

### DIFF
--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -475,7 +475,7 @@ export class BpmnEditor extends CachedComponent {
       modeler
     } = this.getCached();
 
-    const engineProfile = engineProfileOverride || cachedEngineProfile;    
+    const engineProfile = engineProfileOverride || cachedEngineProfile;
 
     if (!engineProfile) {
       return;

--- a/client/src/app/tabs/bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/bpmn/BpmnEditor.js
@@ -421,7 +421,7 @@ export class BpmnEditor extends CachedComponent {
       moveCanvas: canvasFocused,
       moveToOrigin: canvasFocused,
       moveSelection: canvasFocused && !!selectionLength,
-      paste: !modeler.get('clipboard').isEmpty(),
+      paste: true,
       platform: 'platform',
       propertiesPanel: true,
       redo: canvasFocused && commandStack.canRedo(),

--- a/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
+++ b/client/src/app/tabs/bpmn/__tests__/BpmnEditorSpec.js
@@ -620,7 +620,7 @@ describe('<BpmnEditor>', function() {
           lassoTool: true,
           moveCanvas: true,
           moveToOrigin: true,
-          paste: false,
+          paste: true,
           redo: true,
           removeSelected: false,
           replaceElement: false,

--- a/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
+++ b/client/src/app/tabs/cloud-bpmn/BpmnEditor.js
@@ -440,7 +440,7 @@ export class BpmnEditor extends CachedComponent {
       moveCanvas: canvasFocused,
       moveToOrigin: canvasFocused,
       moveSelection: canvasFocused && !!selectionLength,
-      paste: !modeler.get('clipboard').isEmpty(),
+      paste: true,
       platform: 'cloud',
       propertiesPanel: true,
       redo: canvasFocused && commandStack.canRedo(),


### PR DESCRIPTION
### Proposed Changes

After copying an element paste should be enabled and insert the copied element(s) into the diagram (same behaviour as v1.2.0).

closes #114