### PR TITLE
fix(react18): harden tab update-cycle and callback lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to the [Fluxnova Modeler](https://github.com/finos/fluxnova-
 
 ## 1.3.1
 
-- Fixed deep links to use correct Fluxnova Monitoring URL path
+- Fixed deep links to use correct Fluxnova Monitoring URL path (#108)
+- Hardened React 18 tab update-cycle and callback lifecycle behavior (#113)
+- Fixed BPMN canvas copy/paste (#114)
 
 ## 1.3.0
 

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxnova-modeler",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Fluxnova Modeler for BPMN, DMN and CMMN, based on bpmn.io",
   "private": true,
   "main": "prod.js",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxnova-modeler-client",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Fluxnova Modeler client application",
   "private": true,
   "license": "MIT",

--- a/client/src/app/App.js
+++ b/client/src/app/App.js
@@ -88,6 +88,8 @@ const FILTER_ALL_EXTENSIONS = {
   extensions: [ '*' ]
 };
 
+const EMPTY_LINTING_STATE = [];
+
 const INITIAL_STATE = {
   activeTab: EMPTY_TAB,
   dirtyTabs: {},
@@ -852,13 +854,14 @@ export class App extends PureComponent {
 
 
   /**
-   * Mark a tab as shown.
+   * Mark tab as shown if it's active tab, otherwise ignore.
    *
-   * @param {Object} tab descriptor
-   *
-   * @return {Function} tab shown callback
+   * @param {Tab} tab
    */
-  handleTabShown = (tab) => () => {
+  handleTabShown = (tab) => {
+    if (tab !== this.state.activeTab) {
+      return;
+    }
 
     const {
       openedTabs,
@@ -866,11 +869,7 @@ export class App extends PureComponent {
       tabShown
     } = this.state;
 
-    if (tab === activeTab) {
-      tabShown.resolve();
-    } else {
-      tabShown.reject(new Error('tab miss-match'));
-    }
+    tabShown.resolve();
 
     this.setState({
       openedTabs: {
@@ -882,44 +881,54 @@ export class App extends PureComponent {
   };
 
   /**
-   * Handle tab error.
+   * Handle tab error if it is active tab, otherwise ignore.
    *
-   * @param {Object} tab descriptor
-   *
-   * @return {Function} tab error callback
+   * @param {Tab} tab
+   * @param {Error} error
    */
-  handleTabError = (tab) => (error) => {
-    this.handleError(error, tab);
+  handleTabError = (tab, error) => {
+    if (tab !== this.state.activeTab) {
+      return;
+    }
+
+    this.handleError(error, this.state.activeTab);
   };
 
   /**
-   * Handle tab warning.
+   * Handle tab warning if it is active tab, otherwise ignore.
    *
-   * @param {Object} tab descriptor
-   *
-   * @return {Function} tab warning callback
+   * @param {Tab} tab
+   * @param {Error|{ message: string }} warning
    */
-  handleTabWarning = (tab) => (warning) => {
-    this.handleWarning(warning, tab);
+  handleTabWarning = (tab, warning) => {
+    if (tab !== this.state.activeTab) {
+      return;
+    }
+
+    this.handleWarning(warning, this.state.activeTab);
   };
 
   /**
-   * Handle tab changed.
+   * Handle tab changed if it is active tab, otherwise ignore.
    *
-   * @param {Object} tab descriptor
-   *
-   * @return {Function} tab changed callback
+   * @param {Tab} tab
+   * @param {Object} properties
    */
-  handleTabChanged = (tab) => (properties = {}) => {
+  handleTabChanged = (tab, properties = {}) => {
 
-    let {
+    if (tab !== this.state.activeTab) {
+      return;
+    }
+
+    const {
+      activeTab,
       tabState
     } = this.state;
 
     let dirtyState = {};
 
     if ('dirty' in properties) {
-      dirtyState = this.setDirty(tab, properties.dirty);
+      dirtyState = this.setDirty(activeTab, properties.dirty);
     }
 
     this.setState({
@@ -964,7 +973,7 @@ export class App extends PureComponent {
   };
 
   getLintingState = (tab) => {
-    return this.state.lintingState[ tab.id ] || [];
+    return this.state.lintingState[ tab.id ] || EMPTY_LINTING_STATE;
   };
 
   setLintingState = (tab, results) => {
@@ -2132,10 +2141,10 @@ export class App extends PureComponent {
                       tab={ activeTab }
                       layout={ layout }
                       linting={ this.getLintingState(activeTab) }
-                      onChanged={ this.handleTabChanged(activeTab) }
-                      onError={ this.handleTabError(activeTab) }
-                      onWarning={ this.handleTabWarning(activeTab) }
-                      onShown={ this.handleTabShown(activeTab) }
+                      onChanged={ this.handleTabChanged }
+                      onError={ this.handleTabError }
+                      onWarning={ this.handleTabWarning }
+                      onShown={ this.handleTabShown }
                       onLayoutChanged={ this.handleLayoutChanged }
                       onContextMenu={ this.openTabMenu }
                       onAction={ this.triggerAction }
@@ -2249,7 +2258,7 @@ function missingProvider(providerType) {
   class MissingProviderTab extends PureComponent {
 
     componentDidMount() {
-      this.props.onShown();
+      this.props.onShown(this.props.tab);
     }
 
     render() {

--- a/client/src/app/EmptyTab.js
+++ b/client/src/app/EmptyTab.js
@@ -22,7 +22,7 @@ import {
 export default class EmptyTab extends PureComponent {
 
   componentDidMount() {
-    this.props.onShown();
+    this.props.onShown(this.props.tab);
   }
 
   triggerAction() { }

--- a/client/src/app/__tests__/AppSpec.js
+++ b/client/src/app/__tests__/AppSpec.js
@@ -120,7 +120,7 @@ describe('<App>', function() {
         });
 
         // when
-        app.handleTabChanged()();
+        app.handleTabChanged(app.state.activeTab);
 
         // then
         // 1 - tab render
@@ -1317,7 +1317,7 @@ describe('<App>', function() {
       const onTabChanged = spy(function(tab, oldTab) {
         events.push([ 'tab-changed', tab ]);
 
-        app.handleTabShown(tab)();
+        app.handleTabShown();
       });
 
       const onTabShown = spy(function(tab) {
@@ -2363,7 +2363,7 @@ describe('<App>', function() {
     class CustomEmptyTab extends Component {
 
       componentDidMount() {
-        this.props.onShown();
+        this.props.onShown(this.props.tab);
       }
 
       render() {

--- a/client/src/app/__tests__/mocks/index.js
+++ b/client/src/app/__tests__/mocks/index.js
@@ -51,10 +51,11 @@ class FakeTab extends Component {
 
   componentDidMount() {
     const {
-      onShown
+      onShown,
+      tab
     } = this.props;
 
-    onShown();
+    onShown(tab);
   }
 
   componentDidUpdate() {
@@ -80,11 +81,11 @@ class FakeTab extends Component {
     }
 
     if (action === 'error') {
-      this.props.onError(options);
+      this.props.onError(this.props.tab, options);
     }
 
     if (action === 'warning') {
-      this.props.onWarning(options);
+      this.props.onWarning(this.props.tab, options);
     }
 
     if (action === 'errorThrow') {

--- a/client/src/app/slot-fill/SlotFillRoot.js
+++ b/client/src/app/slot-fill/SlotFillRoot.js
@@ -31,6 +31,7 @@ export default class SlotFillRoot extends PureComponent {
     };
 
     this.uid = 7913;
+    this.previousProps = new WeakMap();
 
     this.fillContext = {
 
@@ -47,7 +48,20 @@ export default class SlotFillRoot extends PureComponent {
           id = newFill.id = this.uid++;
         }
 
+        const previousProps = this.previousProps.get(newFill);
+        const propsChanged = previousProps !== newFill.props;
+
+        this.previousProps.set(newFill, newFill.props);
+
         this.setState((state) => {
+
+          const existingFill = state.fills.find(fill => fill.id === id);
+
+          // Avoid redundant updates for unchanged fill registrations, while
+          // still propagating updates when fill props changed.
+          if (existingFill === newFill && !propsChanged) {
+            return null;
+          }
 
           let found = false;
 
@@ -79,6 +93,12 @@ export default class SlotFillRoot extends PureComponent {
        */
       removeFill: (fill) => {
         this.setState((state) => {
+          const hasFill = state.fills.some(f => f.id === fill.id);
+
+          if (!hasFill) {
+            return null;
+          }
+
           return {
             fills: state.fills.filter(f => f.id !== fill.id)
           };

--- a/client/src/app/slot-fill/__tests__/SlotFillSpec.js
+++ b/client/src/app/slot-fill/__tests__/SlotFillSpec.js
@@ -62,6 +62,36 @@ describe('slot-fill', function() {
       );
     });
 
+
+    it('should not update state when re-registering same fill instance', function() {
+      const slotFillRoot = new SlotFillRoot({ });
+
+      let stateTransitions = 0;
+
+      slotFillRoot.setState = (updater) => {
+        const nextState = updater(slotFillRoot.state);
+
+        if (!nextState) {
+          return;
+        }
+
+        slotFillRoot.state = {
+          ...slotFillRoot.state,
+          ...nextState
+        };
+
+        stateTransitions++;
+      };
+
+      const fill = { id: 42 };
+
+      slotFillRoot.fillContext.addFill(fill);
+      slotFillRoot.fillContext.addFill(fill);
+
+      expect(slotFillRoot.state.fills).to.have.length(1);
+      expect(stateTransitions).to.equal(1);
+    });
+
   });
 
 

--- a/client/src/app/tabs/EditorTab.js
+++ b/client/src/app/tabs/EditorTab.js
@@ -37,11 +37,11 @@ export function createTab(tabName, providers) {
     }
 
     componentDidCatch(error, info) {
-      this.props.onError(error, info);
+      this.props.onError(this.props.tab, error, info);
     }
 
     componentDidMount() {
-      this.props.onShown();
+      this.props.onShown(this.props.tab);
     }
 
     render() {

--- a/client/src/app/tabs/MultiSheetTab.js
+++ b/client/src/app/tabs/MultiSheetTab.js
@@ -88,12 +88,13 @@ export class MultiSheetTab extends CachedComponent {
 
   handleChanged = (newState = {}) => {
     const {
-      onChanged
+      onChanged,
+      tab
     } = this.props;
 
     const dirty = this.isDirty(newState);
 
-    onChanged({
+    onChanged(tab, {
       ...newState,
       dirty
     });
@@ -101,18 +102,20 @@ export class MultiSheetTab extends CachedComponent {
 
   handleError = (error) => {
     const {
-      onError
+      onError,
+      tab
     } = this.props;
 
-    onError(error);
+    onError(tab, error);
   };
 
   handleWarning = (warning) => {
     const {
-      onWarning
+      onWarning,
+      tab
     } = this.props;
 
-    onWarning(warning);
+    onWarning(tab, warning);
   };
 
   /**

--- a/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
+++ b/client/src/app/tabs/__tests__/MultiSheetTabSpec.js
@@ -115,7 +115,7 @@ describe('<MultiSheetTab>', function() {
       // then
       expect(errorSpy).not.to.have.been.called;
       expect(warningSpy).to.have.been.calledTwice;
-      expect(warningSpy.alwaysCalledWith('warning')).to.be.true;
+      expect(warningSpy.alwaysCalledWith(defaultTab, 'warning')).to.be.true;
     });
 
 
@@ -154,7 +154,7 @@ describe('<MultiSheetTab>', function() {
       instance.handleImport(error);
 
       // then
-      expect(errorSpy).to.have.been.calledWith(error);
+      expect(errorSpy).to.have.been.calledWith(defaultTab, error);
       expect(warningSpy).not.to.have.been.called;
       expect(showImportErrorDialogSpy).to.have.been.called;
     });
@@ -180,10 +180,10 @@ describe('<MultiSheetTab>', function() {
       instance.handleImport(error, warnings);
 
       // then
-      expect(errorSpy).to.have.been.calledWith(error);
+      expect(errorSpy).to.have.been.calledWith(defaultTab, error);
 
       expect(warningSpy).to.have.been.calledTwice;
-      expect(warningSpy.alwaysCalledWith('warning')).to.be.true;
+      expect(warningSpy.alwaysCalledWith(defaultTab, 'warning')).to.be.true;
 
       expect(showImportErrorDialogSpy).to.have.been.called;
       expect(displayWarningsNotificationSpy).not.to.have.been.called;

--- a/client/src/app/tabs/cloud-dmn/DmnEditor.js
+++ b/client/src/app/tabs/cloud-dmn/DmnEditor.js
@@ -140,7 +140,7 @@ export class DmnEditor extends CachedComponent {
     if (activeViewer) {
       propertiesPanel = activeViewer.get('propertiesPanel', false);
 
-      if (propertiesPanel) {
+      if (propertiesPanel && this.propertiesPanelRef.current) {
         propertiesPanel.attachTo(this.propertiesPanelRef.current);
       }
 
@@ -167,8 +167,12 @@ export class DmnEditor extends CachedComponent {
     modeler.detach();
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     this.checkImport(prevProps);
+
+    if (prevState?.importing && !this.state.importing) {
+      this.attachPropertiesPanel();
+    }
 
     // We can only notify interested parties about overview open once its parent component was
     // rendered
@@ -180,6 +184,21 @@ export class DmnEditor extends CachedComponent {
 
     if (isCachedStateChange(prevProps, this.props)) {
       this.handleChanged();
+    }
+  }
+
+  attachPropertiesPanel() {
+    const modeler = this.getModeler();
+    const activeViewer = modeler.getActiveViewer();
+
+    if (!activeViewer) {
+      return;
+    }
+
+    const propertiesPanel = activeViewer.get('propertiesPanel', false);
+
+    if (propertiesPanel && this.propertiesPanelRef.current) {
+      propertiesPanel.attachTo(this.propertiesPanelRef.current);
     }
   }
 
@@ -315,7 +334,7 @@ export class DmnEditor extends CachedComponent {
       (!previousActiveView || previousActiveView.element !== activeView.element)) {
       propertiesPanel = activeViewer.get('propertiesPanel', false);
 
-      if (propertiesPanel) {
+      if (propertiesPanel && this.propertiesPanelRef.current) {
         propertiesPanel.attachTo(this.propertiesPanelRef.current);
       }
     }
@@ -439,7 +458,7 @@ export class DmnEditor extends CachedComponent {
     } else if (activeView.type === 'literalExpression') {
       assign(newState, {
         defaultCopyCutPaste: true,
-        defaultUndoRedo: true,
+        defaultUndoRedo: inputActive,
         removeSelected: true,
         selectAll: true
       });
@@ -455,7 +474,7 @@ export class DmnEditor extends CachedComponent {
       // TODO(@barmac): handle boxed expression differently than literal expression when needed
       assign(newState, {
         defaultCopyCutPaste: true,
-        defaultUndoRedo: true,
+        defaultUndoRedo: inputActive,
         removeSelected: true,
         selectAll: true
       });
@@ -629,7 +648,13 @@ export class DmnEditor extends CachedComponent {
       return;
     }
 
-    this.open(this.props.activeSheet.element);
+    const { activeSheet } = this.props;
+
+    if (!activeSheet?.element) {
+      return;
+    }
+
+    this.open(activeSheet.element);
   }
 
   shouldOpenActiveSheet(prevProps) {

--- a/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
+++ b/client/src/app/tabs/cloud-dmn/__tests__/DmnEditorSpec.js
@@ -1,0 +1,91 @@
+/* global sinon */
+
+import {
+  DmnEditor
+} from '../DmnEditor';
+
+import diagramXML from './diagram.dmn';
+
+import renderEditorHelper from '../../../__tests__/helpers/renderEditor';
+
+
+const defaultActiveSheet = { id: 'dmn' };
+
+
+describe('<DmnEditor>', function() {
+
+  describe('sheet change guards', function() {
+
+    it('should not open if active sheet element is missing', async function() {
+
+      // given
+      const { instance, rerender } = await renderEditor(diagramXML);
+      const openSpy = sinon.spy(instance, 'open');
+
+      // when
+      rerender(diagramXML, {
+        activeSheet: {
+          id: 'DecisionTable'
+        }
+      });
+
+      // then
+      expect(openSpy).to.not.have.been.called;
+    });
+
+  });
+
+
+  describe('properties panel guards', function() {
+
+    it('should not attach properties panel if panel ref is missing', async function() {
+
+      // given
+      const { instance } = await renderEditor(diagramXML);
+
+      const modeler = instance.getModeler();
+      const propertiesPanel = modeler.getActiveViewer().get('propertiesPanel');
+      const propertiesAttachSpy = sinon.spy(propertiesPanel, 'attachTo');
+
+      instance.propertiesPanelRef.current = null;
+
+      // when
+      instance.attachPropertiesPanel();
+
+      // then
+      expect(propertiesAttachSpy).to.not.have.been.called;
+    });
+
+
+    it('should attach properties panel after import has finished', async function() {
+
+      // given
+      const { instance } = await renderEditor(diagramXML);
+      const attachPropertiesPanelSpy = sinon.spy(instance, 'attachPropertiesPanel');
+
+      // when
+      await instance.componentDidUpdate({
+        activeSheet: defaultActiveSheet,
+        xml: diagramXML
+      }, {
+        importing: true
+      });
+
+      // then
+      expect(attachPropertiesPanelSpy).to.have.been.calledOnce;
+    });
+
+  });
+
+});
+
+
+// helpers //////////
+
+function renderEditor(xml, options = {}) {
+  return renderEditorHelper(DmnEditor, xml, {
+    activeSheet: defaultActiveSheet,
+    onSheetsChanged: () => {},
+    ...options
+  });
+}

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
     },
     "app": {
       "name": "fluxnova-modeler",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@camunda8/sdk": "^8.7.28",
@@ -75,7 +75,7 @@
     },
     "client": {
       "name": "fluxnova-modeler-client",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@bpmn-io/add-exporter": "^0.2.0",


### PR DESCRIPTION
### Proposed Changes

This PR resolves an issue that manifested on Windows where a tab would crash when you tried to open a BPMN file from File Explorer when the modeler was already open. Root cause was that the SlotFillRoot component needed some guards following React 18 migration to ensure that state was not continuously updated when there are no actual state changes.

closes #113 
