### PR TITLE
upgrade to nodejs 24

### DIFF
--- a/.github/workflows/BUILD_ON_DEMAND.yml
+++ b/.github/workflows/BUILD_ON_DEMAND.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         cache: 'npm'
 
     - name: Install dependencies

--- a/.github/workflows/BUILD_ON_MERGE.yml
+++ b/.github/workflows/BUILD_ON_MERGE.yml
@@ -24,11 +24,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         cache: 'npm'
 
     - name: Install npm dependencies

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         cache: 'npm'
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -43,11 +43,11 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         cache: 'npm'
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/TEST.yml
+++ b/.github/workflows/TEST.yml
@@ -21,11 +21,11 @@ jobs:
       BUILD_NUMBER: ${{ github.run_number }}-${{ github.run_id }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         cache: 'npm'
     - name: Install npm dependencies
       run: npm install


### PR DESCRIPTION
This pull request updates all GitHub Actions workflow files to use the latest major versions of the actions/checkout and actions/setup-node actions, and upgrades the Node.js version from 22 to 24. These changes help keep the CI/CD pipeline up to date and ensure compatibility with the latest Node.js features and security patches.

**Workflow dependency updates:**
Updated actions/checkout to version 6 in .github/workflows/BUILD_ON_DEMAND.yml, .github/workflows/BUILD_ON_MERGE.yml, .github/workflows/CI.yml, .github/workflows/RELEASE.yml, and .github/workflows/TEST.yml. 

**Node.js version upgrade:**
Changed the Node.js version from 22 to 24 in all workflow files to use the latest LTS release.